### PR TITLE
nagios: new space for nagios monitors

### DIFF
--- a/nagios/dqsegdb-nagios-latency
+++ b/nagios/dqsegdb-nagios-latency
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+"""Query a DQSegDB URL for a flag and print the latency of the latest data
+
+This script outputs JSON in the format specified for dashboard.ligo.org
+https-shib scraping.
+"""
+
+import argparse
+import re
+import urlparse
+import json
+
+from glue.segments import (segment, segmentlist)
+from dqsegdb.apicalls import dqsegdbQueryTimes as query
+
+__author__ = 'Ryan Fisher <ryan.fisher@ligo.org>'
+__credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+FLAG_REGEX = re.compile(
+    r"\A(?P<ifo>[A-Z]\d):(?P<tag>[^/]+):(?P<version>\d+)\Z")
+
+# -- define command line ------------------------
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('gps-start-time', type=int, help='GPS start time of query')
+parser.add_argument('gps-end-time', type=int, help='GPS end time of query')
+parser.add_argument('flag', help='name of DQ flag to query, must be complete, '
+                    'e.g. L1:ODC-MASTER_SUMMARY:1')
+parser.add_argument('-u', '--url', default='https://dqsegdb5.phy.syr.edu',
+                    help='URL of (DQSegDB) segment database to test, '
+                         'default: %(default)s')
+parser.add_argument('--warning', type=float, default=15*60,
+                    help='latency (seconds) above which the database is in a '
+                         '\'warning\' state, default: %(default)s')
+parser.add_argument('--critical', type=float, default=20*60,
+                    help='latency (seconds) above which the database is in a '
+                         '\'critical\' state, default: %(default)s')
+parser.add_argument('--unknown', type=float, default=30*60,
+                    help='time (seconds) above which the output of this '
+                         'monitor is to be considered stale, '
+                         'default: %(default)s')
+parser.add_argument('--json', action='store_true',
+                    help='write to JSON, default: %(default)s')
+
+# -- parse command line and unpack --------------
+args = parser.parse_args()
+start = getattr(args, 'gps-start-time')
+end = getattr(args, 'gps-end-time')
+flag = args.flag
+try:
+    match = FLAG_REGEX.match(flag).groupdict()
+except AttributeError:
+    parser.error("Cannot parse %r into <ifo>:<flag-name>:<version>, "
+                 "please reformat" % flag)
+url = urlparse.urlparse(args.url)
+
+# -- query the database and calculate the latency
+result, _ = query(url.scheme, url.netloc, match['ifo'], match['tag'],
+                  int(match['version']), 'known', start, end)
+try:
+    latest = segmentlist(map(segment, result['known'])).coalesce()[-1][-1]
+except IndexError as e:
+    e.args = ('No known segments found for flag %r in given interval'
+              % flag,)
+    raise
+
+latency = end - latest
+
+# -- format info JSON and print to screen -------
+latencys = "latency for %s in %s is %d seconds" % (flag, url.geturl(), latency)
+if latency < args.warning:
+    state = 0
+    message = "OK: %s" % latencys
+elif latency < args.critical:
+    state = 1
+    message = "WARNING: %s" % latencys
+else:
+    state = 2
+    message = "CRTICAL: %s" % latencys
+
+if args.json:
+    out = {}
+    out = {
+        'created_gps': end,
+        'status_intervals': [
+            {'start_sec': 0,
+             'num_status': state,
+             'txt_status': message},
+            {'start_sec': int(args.unknown),
+             'num_status': 3,
+             'txt_status': ('UNKNOWN: %s latency check for %s not updating'
+                            % (url.geturl(), flag))},
+        ],
+    }
+    print(json.dumps(out))
+else:
+    print(message)
+sys.exit(state)

--- a/nagios/dqsegdb-nagios-ping
+++ b/nagios/dqsegdb-nagios-ping
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Ping a DQSegDB server and report status
+#
+# Usage: dqsegdb-nagios-ping <hostname> [<timeout>] [--json]
+#
+# Optional <timeout> argument will print
+
+URL=$1
+shift
+TIMER=$1
+if [ "$TIMER" == "--json" ]; then
+    JSON=1
+elif [ -n "$TIMER" ]; then
+    JSON=1
+else
+    shift
+    if [ -z "$1" ]; then
+        JSON=0
+    else
+        JSON=1
+    fi
+fi
+echo $JSON
+
+if [ -z "$TIMER" -o "$TIMER" == "--json" ]; then
+    TIMER=600
+fi
+
+TIMEOUT="UNKNOWN: ping test for $URL is not updating"
+
+MESSAGE=`ligolw_segment_query_dqsegdb --ping --segment-url $URL 2>&1`
+EXITCODE=$?
+
+if [ "$EXITCODE" -eq 0 ]; then
+    NUM=0
+    TXT="SUCCESS"
+else
+    MESSAGE=`echo "$MESSAGE" | awk 'END{print}'`
+    NUM=2
+    TXT="CRITICAL: $URL ping test failed"
+fi
+
+if [ "$JSON" -eq 1 ]; then
+    echo "{\"created_gps\": `lalapps_tconvert 2>/dev/null`, \"status_intervals\": [{\"start_sec\": 0, \"txt_status\": \"${TXT}: ${MESSAGE}\", \"num_status\": $NUM}, {\"start_sec\": $TIMER, \"txt_status\": \"$TIMEOUT\", \"num_status\": 3}]}"
+    exit $EXITCODE
+else
+    echo "${TXT}: ${MESSAGE}"
+    exit $NUM
+fi


### PR DESCRIPTION
This commit adds a new directory for nagios monitoring scripts, with two monitors

- `dqsegdb-nagios-latency`: a python script to attempt to query a server
  for the latest segment for a given flag, and will report if the latency
  is within given limits
- `dqsegdb-nagios-ping`: a bash script to ping a server using the
  dqsegdb client tool `ligolw_segment_query_dqsegdb`

Both monitors default to standard nagios plugin output, with an exicode [0-3] and a line of text, however, both tools accept a '--json' argument to write instead a json packet (to stdout) that can be scraped by the https://dashboard.ligo.org https-json scraper