### PR TITLE
ligolw_segments_from_cats_dqsegdb: restore columns

### DIFF
--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -290,9 +290,6 @@ def kludge_get_column_info(connection, table_name):
 
 if __name__ == '__main__':
     # Settings
-    del lsctables.ProcessTable.validcolumns['domain']
-    del lsctables.ProcessTable.validcolumns['jobid']
-    del lsctables.ProcessTable.validcolumns['is_online']
 
     dbtables.get_column_info = kludge_get_column_info
 


### PR DESCRIPTION
This PR fixes #2 by removing lines that delete valid columns from the Process table. See [here](https://ligo-vcs.phys.uwm.edu/cgit/lalsuite/commit/glue/bin/ligolw_segments_from_cats?id=635fa4fca799ad12367851b22a56b917b5051c01) for corresponding fix in `glue`.