### PR TITLE
switch dependency back to git

### DIFF
--- a/etc/dqsegdb.spec
+++ b/etc/dqsegdb.spec
@@ -14,7 +14,7 @@ Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
 Requires: python, python-pyRXP, glue >= 1.47
-BuildRequires: python-setuptools, git2u
+BuildRequires: python-setuptools, git
 BuildArch: noarch
 Vendor: Ryan Fisher <ryan.fisher@ligo.org>
 


### PR DESCRIPTION
don't force the use of the ius repository

It's been decided not to require the IUS repository, therefore this commit switches the git dependency back to the system git. The git package from IUS, whilst being called git2u is also configured so that it satisfies dependencies on git so this will work even if a system has git from the IUS repo installed.