### PR TITLE
Added missing import in clientutils

### DIFF
--- a/dqsegdb/clientutils.py
+++ b/dqsegdb/clientutils.py
@@ -24,6 +24,7 @@ from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
 from glue.ligolw import utils
+from glue.ligolw import types as ligolwtypes
 
 from glue.ligolw.utils import ligolw_add
 from glue.ligolw.utils import process

--- a/dqsegdb/clientutils.py
+++ b/dqsegdb/clientutils.py
@@ -20,21 +20,16 @@ import tempfile
 
 import glue.segments
 
-from glue.ligolw import ligolw
 from glue.ligolw import table
 from glue.ligolw import lsctables
-from glue.ligolw import utils
 from glue.ligolw import types as ligolwtypes
 
-from glue.ligolw.utils import ligolw_add
-from glue.ligolw.utils import process
-from glue.segmentdb import query_engine
 from glue.segmentdb import segmentdb_utils
 
 from glue.ligolw.utils import ligolw_sqlite
 from glue.ligolw import dbtables
 from glue import segments
-import json
+
 from dqsegdb import jsonhelper
 
 


### PR DESCRIPTION
This PR makes two changes to the `clientutils.py` module:

- adds missing `glue.ligolw.types` import required by `ShowTypesResult.get_pyvalue` method
- removes unused imports