### PR TITLE
Replaced all instances of print statement with print() function

### DIFF
--- a/bin/ligolw_arbitrary_publish_generation.py
+++ b/bin/ligolw_arbitrary_publish_generation.py
@@ -188,7 +188,7 @@ elif site=='SYR' and S6:
     elif interferometer=="H" or interferometer=="L":
         input_directory="/frames/dmt/L${inf}O/triggers/DQ_Segments"
 else:
-    print "ER5 DQXML not at SYR for all times"
+    print("ER5 DQXML not at SYR for all times")
     raise ValueError
 
 
@@ -243,8 +243,8 @@ script_fh.write(script_text)
 script_fh.close()
 
 if mode=="single":
-    print "Run the following command:"
-    print " ".join([executable_name,interferometer,str(start_time),str(end_time)])
+    print("Run the following command:")
+    print(" ".join([executable_name,interferometer,str(start_time),str(end_time)]))
     sys.exit()
 
 ## Generate sub file and dag file

--- a/bin/ligolw_dq_query_dqsegdb
+++ b/bin/ligolw_dq_query_dqsegdb
@@ -176,7 +176,7 @@ def get_full_name(ifo, name, version):
 #        for ifo, name, version, start_time, end_time in rows:
 #            full_name = get_full_name(ifo, name, version)
 #            in_times[full_name] = [start_time, end_time]
-#            print '%-45s [%d %d %d)' % (full_name, start_time, tm, end_time)
+#            print('%-45s [%d %d %d)' % (full_name, start_time, tm, end_time))
 #
 #        if not in_segments_only:
 #            # Segments we are between. Latest end time before of interest.
@@ -208,7 +208,7 @@ def get_full_name(ifo, name, version):
 #            for key in out_times:
 #                if key not in in_times:
 #                    value = out_times[key]
-#                    print '%-45s %s %d %s' % (key, value[0], tm, value[1])
+#                    print('%-45s %s %d %s' % (key, value[0], tm, value[1]))
 #
 #
 #def run_active(doc, process_id, engine, include_segments, times):
@@ -320,9 +320,9 @@ if __name__ == '__main__':
         end_pad = 10
 
     time_seg = segments.segment(int(time) - start_pad, int(time) + end_pad)
-    print "Window Queried:"
-    print time_seg
-    print "==============="
+    print("Window Queried:")
+    print(time_seg)
+    print("===============")
 
     # First print active segments in window:
     result,query_url=apicalls.reportActive(protocol,server,True,False,time_seg[0],time_seg[1])
@@ -356,22 +356,22 @@ if __name__ == '__main__':
     else:
         tom=True
     if not options.seperate_good_from_bad:
-        print "Flags active in provided window:"
+        print("Flags active in provided window:")
         for i in active_results:
             if tom==True:
                 text="Flag name: "
                 text+=i
                 text+=" ; Active: "
                 text+=str(active_results[i])
-                print text
+                print(text)
             else:
-                print "Flag name:"
-                print i
-                print "Active segments:"
-                print active_results[i]
+                print("Flag name:")
+                print(i)
+                print("Active segments:")
+                print(active_results[i])
     else:
         active_results_bad={}
-        print "Flags active in provided window that indicate bad ifo state:"
+        print("Flags active in provided window that indicate bad ifo state:")
         for i in active_results:
             if i not in active_results_not_bad:
                 if tom==True:
@@ -379,13 +379,13 @@ if __name__ == '__main__':
                     text+=i
                     text+=" ; Active: "
                     text+=str(active_results[i])
-                    print text
+                    print(text)
                 else:
-                    print "Flag name:"
-                    print i
-                    print "Active segments:"
-                    print active_results[i]
-        print "Flags active in provided window that indicate good ifo state:"
+                    print("Flag name:")
+                    print(i)
+                    print("Active segments:")
+                    print(active_results[i])
+        print("Flags active in provided window that indicate good ifo state:")
         for i in active_results:
             if i in active_results_not_bad:
                 if tom==True:
@@ -393,18 +393,18 @@ if __name__ == '__main__':
                     text+=i
                     text+=" ; Active: "
                     text+=str(active_results[i])
-                    print text
+                    print(text)
                 else:
-                    print "Flag name:"
-                    print i
-                    print "Active segments:"
-                    print active_results[i]
+                    print("Flag name:")
+                    print(i)
+                    print("Active segments:")
+                    print(active_results[i])
 
     # Now print defined but inactive flag types:
     if not options.active_only:
         known_result,query_url=apicalls.reportKnown(protocol,server,True,False,time_seg[0],time_seg[1])
         known_dict=json.loads(known_result)
-        print "Flags defined, but contain no active segments in requested window:"
+        print("Flags defined, but contain no active segments in requested window:")
         known_results={}
         for i in known_dict['results']:
             ifo=i['ifo']
@@ -424,13 +424,13 @@ if __name__ == '__main__':
                             known_results[flag_string]=segments.segmentlist([segments.segment(start_time,end_time)])
                         else:
                             known_results[flag_string].append(segments.segment(start_time,end_time))
-                    print text
+                    print(text)
                 else:
-                    print "Flag name:"
-                    print flag_string
-                    print "Known times overlapping window:"
+                    print("Flag name:")
+                    print(flag_string)
+                    print("Known times overlapping window:")
                     for j in i['known']:
-                        print j
+                        print(j)
                         start_time=j[0]
                         end_time=j[1]
                         if flag_string not in known_results:
@@ -438,7 +438,7 @@ if __name__ == '__main__':
                         else:
                             known_results[flag_string].append(segments.segment(start_time,end_time))
         if options.seperate_good_from_bad:
-            print "Flags marked as active means ifo operating well, that are defined but inactive in this period.  These should be considered as possible vetoes!"
+            print("Flags marked as active means ifo operating well, that are defined but inactive in this period.  These should be considered as possible vetoes!")
             for i in known_dict['results']:
                 ifo=i['ifo'] 
                 name=i['name'] 
@@ -452,13 +452,13 @@ if __name__ == '__main__':
                             text+=" ; Known Times overlapping query with no active times: "
                             for j in i['known']:
                                 text+=" "+str(j)+" "
-                            print text
+                            print(text)
                         else:
-                            print "Flag name:"
-                            print flag_string
-                            print "Known times overlapping window with no active times:"
+                            print("Flag name:")
+                            print(flag_string)
+                            print("Known times overlapping window with no active times:")
                             for j in i['known']:
-                                print j
+                                print(j)
 
     if options.output_file:
         # Build json output file:

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb
@@ -29,6 +29,8 @@ Example call to function:
 ligolw_publish_threaded_dqxml_dqsegdb --segment-url http://slwebtest.virgo.infn.it --state-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/spool/L-DQ_Segments_long_test.xml --pid-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/run/L-DQ_Segments.pid --log-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/log/L-DQ_Segments.log --input-directory=/archive/frames/dmt/ER4/DQ/L1 --log-level DEBUG -m 60 -c 20 -e 105819443
 """
 
+from __future__ import print_function
+
 import sys
 import traceback
 import copy
@@ -121,7 +123,7 @@ if not options.segment_url:
 
 #old if options.ping:
 #old   msg = myClient.ping()
-#old   print msg
+#old   print(msg)
 #old   sys.exit(0)
 #old 
 if not options.state_file and not options.segments_file:
@@ -326,7 +328,7 @@ except Exception, e:
     logger.error(str(e))
   except:
     pass
-  print >>sys.stderr, "runtime error (%s)" % str(e)
+  print("runtime error (%s)" % str(e), file=sys.stderr)
   os.unlink(options.pid_file)
   sys.exit(1)
 

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
@@ -63,6 +63,8 @@ Example call to function:
 ligolw_publish_threaded_dqxml_dqsegdb --segment-url http://slwebtest.virgo.infn.it --state-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/spool/L-DQ_Segments_long_test.xml --pid-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/run/L-DQ_Segments.pid --log-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/log/L-DQ_Segments.log --input-directory=/archive/frames/dmt/ER4/DQ/L1 --log-level DEBUG -m 60 -c 20 -e 105819443
 """
 
+from __future__ import print_function
+
 import sys
 import traceback
 import copy
@@ -146,7 +148,7 @@ parser.add_option("-x", "--synchronize", metavar="synchronize", help="Time to ru
 
 options, filenames = parser.parse_args()
 if options.log_level=="DEBUG":
-    print options
+    print(options)
     #sys.exit(5)
 
 testing_options={}
@@ -166,7 +168,7 @@ if not options.segment_url:
 
 #old if options.ping:
 #old   msg = myClient.ping()
-#old   print msg
+#old   print(msg)
 #old   sys.exit(0)
 #old 
 if not options.state_file and not options.segments_file:
@@ -362,7 +364,7 @@ except Exception, e:
     logger.error(str(e))
   except:
     pass
-  print >>sys.stderr, "runtime error (%s)" % str(e)
+  print("runtime error (%s)" % str(e), file=sys.stderr)
   os.unlink(options.pid_file)
   sys.exit(1)
 

--- a/bin/ligolw_segment_insert_dqsegdb
+++ b/bin/ligolw_segment_insert_dqsegdb
@@ -41,13 +41,13 @@ except ImportError:
   try:
     import pyRXP
   except ImportError, e:
-    print >> sys.stderr, """
+    print("""
 Error: unable to import the pyRXP module.
 
 You must have pyRXP installed and in your PYTHONPATH to run %s.
 
 %s
-""" %(sys.argv[0], e)
+""" %(sys.argv[0], e), file=sys.stderr)
 
 try:
   from glue import gpstime
@@ -61,13 +61,13 @@ try:
   from glue.ligolw.utils import process
   from glue.ligolw import types as ligolwtypes 
 except ImportError, e:
-  print >> sys.stderr, """
+  print("""
 Error: unable to import modules from glue.
 
 Check that glue is correctly installed and in your PYTHONPATH.
 
 %s
-""" % e
+""" % e, file=sys.stderr)
   sys.exit(1)
 ##################################################################
 __author__ = "Ryan Fisher <rpfisher@syr.edu>"
@@ -154,8 +154,8 @@ else:
   active_indicates_ifo_goodness=False # default
   
 if len(errmsg) and not options.ping:
-  print >> sys.stderr, errmsg
-  print >> sys.stderr, "Run\n    %s --help\nfor more information." % sys.argv[0]
+  print(errmsg, file=sys.stderr)
+  print("Run\n    %s --help\nfor more information." % sys.argv[0], file=sys.stderr)
   sys.exit(1)
 
 
@@ -165,9 +165,9 @@ if len(errmsg) and not options.ping:
 #o 
 #o if options.ping:
 #o    try:
-#o      print myClient.ping()
+#o      print(myClient.ping())
 #o    except Exception, e:
-#o      print "Error ping --segment-url", str(e)
+#o      print("Error ping --segment-url", str(e))
 #o      sys.exit(1)
 #o else:
 #o ########################################################################
@@ -188,7 +188,7 @@ def publishAndExit(filepath,debug=False):
     raise Exception("Call to InsertMultipleDQXMLFileThreaded returned failure status:  Publishing unsuccessful!")
   else:
     # We're done here
-    print "Insert worked!"
+    print("Insert worked!")
     sys.exit()
 
 def del_file(name):
@@ -245,11 +245,11 @@ server=o.netloc
 version=int(options.version)
 
 if debug:
-  print "Determining max version"
+  print("Determining max version")
 maxVersion=apicalls.dqsegdbMaxVersion(protocol,server,options.ifos,options.name)
 if debug:
-  print "maxVersion=%d" % maxVersion
-  print "Script call provided version=%d" % version
+  print("maxVersion=%d" % maxVersion)
+  print("Script call provided version=%d" % version)
 
 if version > maxVersion+1:
   # Should never insert or append to a version that is a 2 steps up from current version in db (including current version in DB = 0 case that is returned when flag does not yet exist in the database)
@@ -261,23 +261,23 @@ if maxVersion == 0:
   maxEndTime=0 ## Because this flag doesn't exist yet!
 elif maxVersion > version:
   # Fail!
-  print "Version in DB (%d) is greater than that specified (%d), exiting with error." % (maxVersion,version)
+  print("Version in DB (%d) is greater than that specified (%d), exiting with error." % (maxVersion,version))
   raise ValueError
 elif maxVersion == version and options.insert:
   # Fail!
-  print "Version in DB (%d) is equal to that specified (%d) for insertion, exiting with error." % (maxVersion,version)
+  print("Version in DB (%d) is equal to that specified (%d) for insertion, exiting with error." % (maxVersion,version))
   raise ValueError
 else:
   # Proceed to grab maxEndTime from server
   if debug:
-    print "Version approved by checks, determining max end time:"
+    print("Version approved by checks, determining max end time:")
   if options.append:
     data_dict,query_url1=apicalls.dqsegdbQueryTimeless(protocol,server,options.ifos,options.name,options.version,include_list_string='known,metadata')
     maxEndTime=max([i[1] for i in data_dict['known']])
   elif options.insert and version == maxVersion + 1:
     maxEndTime=0 # The version is greater than the existing versionsi bye one, so we're ok to go forward regardless of what the summary segments are in the payload!
   else:
-    print "Specified version is not next version available to insert into database;  Existing max version is %d and provided version was %d." % (maxVersion,version)
+    print("Specified version is not next version available to insert into database;  Existing max version is %d and provided version was %d." % (maxVersion,version))
     raise ValueError
 
 
@@ -296,35 +296,35 @@ line_no = 1
 for line in fh.readlines():
   sum_line = line.strip().split(" ")
   if len(sum_line) != 2:
-     print "\nERROR: invalid format in your --summary-file row number: %d " % line_no
-     print "Invalid interval is %s" % str(sum_line)
+     print("\nERROR: invalid format in your --summary-file row number: %d " % line_no)
+     print("Invalid interval is %s" % str(sum_line))
      sys.exit(1)
   current_time = str(gpstime.GpsSecondsFromPyUTC(time.time()))
 
   # make sure gps time is 9 digits
   #if (len(sum_line[0])!=9 or len(sum_line[1])!=9):
-  #   print "\nERROR: gps time must be 9 digits"
-  #   print "Invalid interval in your --summary-file row number: %d " % line_no
-  #   print "Invalid interval is %s" % str(sum_line)
+  #   print("\nERROR: gps time must be 9 digits")
+  #   print("Invalid interval in your --summary-file row number: %d " % line_no)
+  #   print("Invalid interval is %s" % str(sum_line))
   #   sys.exit(1)
   ## make sure interval start time is less than and not equal to end time
   if (int(sum_line[0]) >= int(sum_line[1])):
-     print "\nERROR: start_time MUST be less than the end_time"
-     print "Invalid interval in your --summary-file row number: %d " % line_no
-     print "Invalid interval is %s" % str(sum_line)
+     print("\nERROR: start_time MUST be less than the end_time")
+     print("Invalid interval in your --summary-file row number: %d " % line_no)
+     print("Invalid interval is %s" % str(sum_line))
      sys.exit(1)
   # make sure interval start time is greater than the max end time in the database
   # unless --ignore-append-check is specified or we are inserting a new version
   elif (int(sum_line[0]) < maxEndTime) and options.append and (not options.ignore_append_check):
-     print "\nERROR: summary start_time MUST be greater than the max summary end_time %d in the database" % maxEndTime
-     print "Invalid interval in your --summary-file row number: %d" % line_no
-     print "Invalid interval is %s" % str(sum_line)
+     print("\nERROR: summary start_time MUST be greater than the max summary end_time %d in the database" % maxEndTime)
+     print("Invalid interval in your --summary-file row number: %d" % line_no)
+     print("Invalid interval is %s" % str(sum_line))
      sys.exit(1)
   # make sure interval end time is less than current time
   elif  (int(sum_line[1]) > int(current_time)) and not options.ignore_future:
-     print "\nERROR: summary end_time cannot be greater than the current time"
-     print "Invalid interval in your --summary-file row number: %d " % line_no
-     print "Invalid interval is %s" % str(sum_line)
+     print("\nERROR: summary end_time cannot be greater than the current time")
+     print("Invalid interval in your --summary-file row number: %d " % line_no)
+     print("Invalid interval is %s" % str(sum_line))
      sys.exit(1)
   # if interval is valid, append it to intervals list
   else:
@@ -340,27 +340,27 @@ line_no = 1
 for line in fh.readlines():
   seg_line = line.strip().split(" ")
   if len(seg_line) != 2:
-     print "\nERROR: invalid format in your --segment-file row number: %d " % line_no
-     print "Invalid segment is %s" % str(seg_line)
+     print("\nERROR: invalid format in your --segment-file row number: %d " % line_no)
+     print("Invalid segment is %s" % str(seg_line))
      sys.exit(1)
   # make sure gps time is 9 digits
   #if (len(seg_line[0]) != 9 or len(seg_line[1])!=9): 
-  #   print "\nERROR: gps time must be 9 digits"
-  #   print "Invalid segment in your --segment-file row number: %d" % line_no
-  #   print "Invalid segment is %s" % str(seg_line)
+  #   print("\nERROR: gps time must be 9 digits")
+  #   print("Invalid segment in your --segment-file row number: %d" % line_no)
+  #   print("Invalid segment is %s" % str(seg_line))
   #   sys.exit(1)
   # make sure segment start_time is less than end_time:
   if int(seg_line[0])>=int(seg_line[1]):
-    print "\nERROR: segment start_time MUST be less than the end_time"
-    print "Invalid segment in your --segment-file row number: %d" % line_no
-    print "Invalid segment is %s" % str(seg_line)
+    print("\nERROR: segment start_time MUST be less than the end_time")
+    print("Invalid segment in your --segment-file row number: %d" % line_no)
+    print("Invalid segment is %s" % str(seg_line))
     sys.exit(1)
   # make sure segment falls in the summary  intervals specified in the --summary-file
   this_seg = segments.segment(int(seg_line[0]),int(seg_line[1])) 
   if this_seg not in intervals:
-    print "\nERROR: segment cannot fall outside of the summary intervals specified in your --summary-file"
-    print "Invalid segment in your --segment-file row number: %d" % line_no
-    print "Invalid segment is %s" % str(seg_line)
+    print("\nERROR: segment cannot fall outside of the summary intervals specified in your --summary-file")
+    print("Invalid segment in your --segment-file row number: %d" % line_no)
+    print("Invalid segment is %s" % str(seg_line))
     sys.exit(1)
   # Otherwise, append this segment to the list of active segments
   active_segments.append(this_seg)
@@ -368,7 +368,7 @@ for line in fh.readlines():
 active_segments.coalesce()
 
 if debug:
-    print "Beginning INSERT part of code"
+    print("Beginning INSERT part of code")
 #######################################################################################
 #                            Process INSERT or APPEND
 #######################################################################################
@@ -432,13 +432,13 @@ if options.insert or options.append:
 
     if options.output:
       if debug:
-        print "Writing out to file and then exiting."
+        print("Writing out to file and then exiting.")
       fp = open(options.output,"w")
       fp.write(fake_file.getvalue())
       fp.close()
     else:
       if debug:
-        print "Writing to temporary file, then calling callInsertMultipleDQXMLThreaded"
+        print("Writing to temporary file, then calling callInsertMultipleDQXMLThreaded")
       filepath='/tmp/ligolw_segment_insert_'+str(time.time())+'.xml'
       if not debug:
         atexit.register(del_file,filepath) # 
@@ -452,7 +452,7 @@ if options.insert or options.append:
       #else:
       #    # We're done here
       #    if debug:
-      #      print "Insert worked!"
+      #      print("Insert worked!")
       #    sys.exit()
   else: # Direct to JSON
     ## Result JSON should look like this:
@@ -558,7 +558,7 @@ if options.insert or options.append:
     # for i in flag_versions.values():
     #   i.buildFlagDictFromInsertVersion()
     #   url=i.buildURL(server)
-    #   print json.dumps(i.flagDict)
+    #   print(json.dumps(i.flagDict))
     #   patchWithFailCases(i,url,debug,logger,testing_options)
 
     from dqsegdb.jsonhelper import InsertFlagVersion

--- a/bin/ligolw_segment_query_dqsegdb
+++ b/bin/ligolw_segment_query_dqsegdb
@@ -38,6 +38,7 @@ exactly the format returned by S6 style segment database tools.
 * Example: ligolw_segment_query_dqsegdb --segment-url=http://dqsegdb4.phy.syr.edu --query-segments --gps-start-time 987654321 --gps-end-time 987654333 --include-segments="H1:DMT-SCIENCE:1" -o example.xml
 """
 
+from __future__ import print_function
 
 from optparse import OptionParser
 
@@ -177,7 +178,7 @@ def parse_command_line():
             inurl   = urllib.urlopen(options.segment_url)
             outfile = open(tmp_dir + "/" + fname, 'w')
             for l in inurl:
-                print >>outfile, l,
+                print(l, file=outfile)
 
             inurl.close()
             outfile.close()
@@ -381,7 +382,7 @@ def run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, g
         else:
             versionQueryURL=urifunctions.constructVersionQueryURL(protocol,server,ifo,name) 
             if debug:
-                print versionQueryURL
+                print(versionQueryURL)
             versionResult=urifunctions.getDataUrllib2(versionQueryURL)
             versionData=json.loads(versionResult)  #JSON is nice... :)
             ## Construct urls and issue queries for the multiple versions and dump the results to disk locally for careful provenance
@@ -427,7 +428,7 @@ def run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, g
 
     doc.childNodes[0].appendChild(seg_sum_table)
     if debug:
-        print segment_types
+        print(segment_types)
 
     for key in segment_types:
         # Make sure the intervals fall within the query window and coalesce
@@ -490,7 +491,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
         spec = included.split(':')
 
         if len(spec) < 2 or len(spec) > 3:
-            print >>sys.stderr, "Included segements must be of the form ifo:name:version or ifo:name:*"
+            print("Included segements must be of the form ifo:name:version or ifo:name:*", file=sys.stderr)
             sys.exit(1)
 
         ifo     = spec[0]
@@ -507,14 +508,14 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
             except ValueError:
                 raise ValueError("Bad version specification, please provide a valid integer.")
             if version < 1:
-                print >>sys.stderr, "Segment version numbers must be greater than zero"
+                print("Segment version numbers must be greater than zero", file=sys.stderr)
                 sys.exit(1)
             # call to single version flag query goes here!
             # result is already processed into a python dict using json.loads :
             json_result,queryurl=apicalls.dqsegdbQueryTimesCompatible(protocol,server,ifo,name,version,include_list_string,startTime,endTime)
             if debug:
-                print json_result
-                print queryurl
+                print(json_result)
+                print(queryurl)
             included_JSON_results.append(json_result)
             segdefs.append((ifo, name, version, startTime, endTime, 0, 0))
             known_segments=glue.segments.segmentlist([glue.segments.segment(x[0],x[1]) for x in json_result['known']])
@@ -524,12 +525,12 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
             # Trigger versionless call to return a JSON result here
             json_result,versioned_JSON,affected_results=apicalls.dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, startTime, endTime)
             if debug:
-                print "Cascaded query call results:"
-                print json_result
-                print "Versioned intermediate results"
-                print versioned_JSON
-                print "Affected results segments"
-                print affected_results
+                print("Cascaded query call results:")
+                print(json_result)
+                print("Versioned intermediate results")
+                print(versioned_JSON)
+                print("Affected results segments")
+                print(affected_results)
             # affected_results contains the segments of time that affected the final result for each version used in the calculation
             # This replicates the S6 behavior:
             included_JSON_results.append(json_result)
@@ -550,21 +551,21 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
 
     # And we could write out everything we found
     if debug:
-        print "Information on segdefs and segment_summaries: lengths, then first 10 entries"
-        print len(segdefs)
-        print len(segment_summaries)
+        print("Information on segdefs and segment_summaries: lengths, then first 10 entries")
+        print(len(segdefs))
+        print(len(segment_summaries))
         if len(segdefs) > 10: 
-            print segdefs[:10]
+            print(segdefs[:10])
         else:
-            print segdefs
+            print(segdefs)
         if len(segment_summaries)>10:
-            print "Lots of summaries:"
-            print segment_summaries[:10]
+            print("Lots of summaries:")
+            print(segment_summaries[:10])
         else:
-            print "Segment Summaries:"
-            print segment_summaries
-        print doc
-        print process_id
+            print("Segment Summaries:")
+            print(segment_summaries)
+        print(doc)
+        print(process_id)
     segment_summaries=[glue.segments.segmentlist(x) for x in segment_summaries]
     for x in segment_summaries:
         x.coalesce()
@@ -581,7 +582,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
             spec = excluded.split(':')
 
             if len(spec) < 2 or len(spec) > 3:
-                print >>sys.stderr, "Included segements must be of the form ifo:name:version or ifo:name:*"
+                print("Included segements must be of the form ifo:name:version or ifo:name:*", file=sys.stderr)
                 sys.exit(1)
 
             ifo     = spec[0]
@@ -594,7 +595,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
             if len(spec) is 3 and spec[2] is not '*':
                 version = int(spec[2])
                 if version < 1:
-                    print >>sys.stderr, "Segment version numbers must be greater than zero"
+                    print("Segment version numbers must be greater than zero", file=sys.stderr)
                     sys.exit(1)
                 # call to single version flag query goes here!
                 # result is already processed into a python dict using json.loads :
@@ -637,13 +638,13 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
     # and store the segments
     clientutils.add_to_segment_ns(doc, process_id, seg_def_id, found_segments)
     if debug:
-        print "Result name:"
-        print result_name
-        print "seg_def_id"
-        print seg_def_id
-        print "Found segments:"
-        print type(found_segments)
-        print found_segments
+        print("Result name:")
+        print(result_name)
+        print("seg_def_id")
+        print(seg_def_id)
+        print("Found segments:")
+        print(type(found_segments))
+        print(found_segments)
 
            
 
@@ -709,7 +710,7 @@ if __name__ == '__main__':
     if options.ping:
         if options.use_s6:
             connection = segmentdb_utils.setup_database(database_location)
-            print connection.ping()
+            print(connection.ping())
             sys.exit( 0 )
         else:
             # DQSEGDB 'ping'
@@ -721,7 +722,7 @@ if __name__ == '__main__':
             json_out=urifunctions.getDataUrllib2(url_result)
             flags_information=json.loads(json_out)
             server_version=flags_information['query_information']['api_version']
-            print "Server version is %s" % server_version
+            print("Server version is %s" % server_version)
             sys.exit(0)
             
 

--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -61,6 +61,7 @@ the segments, and produces veto files as XML.  Produces output to match S6
 style segment database tools.
 """
 
+from __future__ import print_function
 
 from optparse import OptionParser
 import urlparse
@@ -160,7 +161,7 @@ def parse_command_line():
    
     # User must specify how to treat the categories
     if not (options.cumulative_categories or options.separate_categories) or (options.cumulative_categories and options.separate_categories):
-        print >>sys.stderr, "Must provide one of --cumulative-categories | --separate-categories"
+        print("Must provide one of --cumulative-categories | --separate-categories", file=sys.stderr)
         sys.exit(-1)
 
     tmp_dir = None
@@ -185,7 +186,7 @@ def parse_command_line():
 
         outfile = open(loaded_file, 'w')
         for l in inurl:
-            print >>outfile, l,
+            print(l, file=outfile)
 
         inurl.close()
         outfile.close()
@@ -212,7 +213,7 @@ def parse_command_line():
             inurl   = urllib.urlopen(options.segment_url)
             outfile = open(tmp_dir + "/" + fname, 'w')
             for l in inurl:
-                print >>outfile, l,
+                print(l, file=outfile)
 
             inurl.close()
             outfile.close()
@@ -418,31 +419,31 @@ if __name__ == '__main__':
                 json_result,queryurl=apicalls.dqsegdbQueryTimesCompatible(protocol,server,ifo,name,version,include_list_string,startTime,endTime)
                 # This pads and truncates to the size of the queried region
                 if debug:
-                    print "Known for %s" % name
-                #print json_result['known']
+                    print("Known for %s" % name)
+                #print(json_result['known'])
                 # NOTE: Adding startpad to match S6, even though it seems backwards!
                 cur_segment_summaries=glue.segments.segmentlist([glue.segments.segment(x[0]+startpad,x[1]+endpad) for x in json_result['known']])
                 cur_segment_summaries.coalesce()
                 if debug:
-                    print cur_segment_summaries
+                    print(cur_segment_summaries)
                 cur_segment_summaries=cur_segment_summaries&glue.segments.segmentlist([glue.segments.segment(startTime,endTime)])
                 if debug:
-                    print "Resulting segment summaries:"
-                    print cur_segment_summaries
+                    print("Resulting segment summaries:")
+                    print(cur_segment_summaries)
                     # This pads and truncates to the size of the queried region
                     #debug:
-                    print "Active for %s" % name
-                    #print json_result['active']
+                    print("Active for %s" % name)
+                    #print(json_result['active'])
                 # NOTE: Adding startpad to match S6, even though it seems backwards!
                 cur_vetoed_segments=glue.segments.segmentlist([glue.segments.segment(x[0]+startpad,x[1]+endpad) for x in json_result['active']])
                 #debug:
                 cur_vetoed_segments.coalesce()
                 if debug:
-                    print cur_vetoed_segments
+                    print(cur_vetoed_segments)
                 cur_vetoed_segments=cur_vetoed_segments&glue.segments.segmentlist([glue.segments.segment(startTime,endTime)])
                 if debug:
-                    print "Resulting segments:"
-                    print cur_vetoed_segments
+                    print("Resulting segments:")
+                    print(cur_vetoed_segments)
                 # And now we add the results to the list!
                 segment_summaries.append(cur_segment_summaries)
                 vetoed_segments.append(cur_vetoed_segments)
@@ -494,5 +495,5 @@ if __name__ == '__main__':
     if not options.keep_db:
         os.remove(temp_db)
     if debug:
-        print "If you see this message, your call to ligolw_segments_from_cats was successful."
-        print "You may want to follow up on any warnings printed before this point, they will indicate any flags that didn't exist in the database but were in the veto definer file."
+        print("If you see this message, your call to ligolw_segments_from_cats was successful.")
+        print("You may want to follow up on any warnings printed before this point, they will indicate any flags that didn't exist in the database but were in the veto definer file.")

--- a/dqsegdb/apicalls.py
+++ b/dqsegdb/apicalls.py
@@ -111,7 +111,7 @@ def dqsegdbMaxVersion(protocol,server,ifo,name):
     try:
         result=urifunctions.getDataUrllib2(queryurl,warnings=False)
     except HTTPError as e:
-        print "e.code: %s  FIX!" % str(e.code)
+        print("e.code: %s  FIX!" % str(e.code))
         if int(e.code)==404:
             return 0
         else:
@@ -288,7 +288,7 @@ def queryAPIVersion(protocol,server,verbose):
     """
     queryurl=protocol+"://"+server+"/dq"
     if verbose:
-        print queryurl
+        print(queryurl)
     result=urifunctions.getDataUrllib2(queryurl)
     dictResult=json.loads(result)
     apiVersion=str(dictResult['query_information']['api_version'])
@@ -311,7 +311,7 @@ def reportFlags(protocol,server,verbose):
     """
     queryurl=protocol+"://"+server+"/report/flags"
     if verbose:
-        print queryurl
+        print(queryurl)
     result=urifunctions.getDataUrllib2(queryurl)
     return result
 
@@ -345,7 +345,7 @@ def reportActive(protocol,server,includeSegments,verbose,gps_start_time,gps_end_
         timeText="&s=%d&e=%d"%(gps_start_time,gps_end_time)
     queryurl=protocol+"://"+server+"/report/active"+includeText+timeText
     if verbose:
-        print queryurl
+        print(queryurl)
     result=urifunctions.getDataUrllib2(queryurl,timeout=1200)
     return result,queryurl
 
@@ -378,7 +378,7 @@ def reportKnown(protocol,server,includeSegments,verbose,gps_start_time,gps_end_t
         timeText="&s=%d&e=%d"%(gps_start_time,gps_end_time)
     queryurl=protocol+"://"+server+"/report/known"+includeText+timeText
     if verbose:
-        print queryurl
+        print(queryurl)
     result=urifunctions.getDataUrllib2(queryurl,timeout=1200)
     return result,queryurl
 
@@ -512,7 +512,7 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
     ## of versions
     versionQueryURL=urifunctions.constructVersionQueryURL(protocol,server,ifo,name)
     if verbose:
-        print versionQueryURL
+        print(versionQueryURL)
     try:
         versionResult=urifunctions.getDataUrllib2(versionQueryURL)
     except HTTPError as e:
@@ -549,7 +549,7 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
             version=versioned_url.split('/')[-1]
             queryurl=urifunctions.constructSegmentQueryURLTimeWindow(protocol,server,ifo,name,version,include_list_string,startTime,endTime)
             if verbose:
-                print queryurl
+                print(queryurl)
             result=urifunctions.getDataUrllib2(queryurl)
             result_parsed=json.loads(result)
             jsonResults.append(result_parsed)
@@ -562,9 +562,9 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
                     tmpfile=open(filename,'w')
                     json.dump(result_parsed,tmpfile)
                     tmpfile.close()
-                    print "Stored partial result for individual version to disk as %s" % filename
+                    print("Stored partial result for individual version to disk as %s" % filename)
                 except:
-                    print "Couldn't save partial results to disk.... continuing anyway."
+                    print("Couldn't save partial results to disk.... continuing anyway.")
 
     ## Construct output segments lists from multiple JSON objects
     # The jsonResults are in order of decreasing versions, 
@@ -575,8 +575,8 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
     # so we're done the math! : 
     result_flag,affected_results=clientutils.calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=ifo)
     if verbose:
-        print "active segments:", result_flag['active']
-        print "known segments:", result_flag['known']
+        print("active segments:", result_flag['active'])
+        print("known segments:", result_flag['known'])
 
     ### Old before JSON spec change:
     ### Need to build the client_meta part of the JSON results
@@ -645,7 +645,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
         #patch to the flag/version
         if debug:
             inlogger.debug("Trying to patch alone for url: %s" % url)
-            #print "Trying to patch alone for url: %s" % url 
+            #print("Trying to patch alone for url: %s" % url)
         if 'synchronize' in testing_options:
             startTime=testing_options['synchronize']
             inlogger.debug("Trying to patch synchronously at time %s" % startTime)
@@ -653,7 +653,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
         patchDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
         if debug:
             inlogger.debug("Patch alone succeeded for %s" % url)
-            #print "Patch alone succeeded for %s" % url
+            #print("Patch alone succeeded for %s" % url)
     except HTTPError as e:
         if e.code!=404:
             raise e
@@ -661,11 +661,11 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
             #put to version
             if debug:
                 inlogger.debug("Trying to put alone for url: %s" % url)
-                #print "Trying to put alone for %s" % url
+                #print("Trying to put alone for %s" % url)
             putDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
             if debug:
                 inlogger.debug("Put alone succeeded for %s" % url)
-                #print "Put alone succeeded for %s" % url
+                #print("Put alone succeeded for %s" % url)
         except HTTPError as ee:
             if ee.code!=404:
                 raise ee
@@ -673,13 +673,13 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
             suburl='/'.join(url.split('/')[:-1])
             if debug:
                 inlogger.debug("Trying to PUT flag and version to: %s" % suburl)
-                #print "Trying to PUT flag and version to: "+suburl
+                #print("Trying to PUT flag and version to: "+suburl)
             putDataUrllib2(suburl,json.dumps(i.flagDict),logger=inlogger)
             #put to version
             putDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
             if debug:
                 inlogger.debug("Had to PUT flag and version")
-                #print "Had to PUT flag and version"
+                #print("Had to PUT flag and version")
 
 
 def threadedPatchWithFailCases(q,server,debug,inputlogger=None):
@@ -693,7 +693,7 @@ def threadedPatchWithFailCases(q,server,debug,inputlogger=None):
         try:
             patchWithFailCases(i,url,debug,inlogger=inputlogger)
         except KeyboardInterrupt:
-            print "interrupted by user!"
+            print("interrupted by user!")
             sys.exit(1)
         q.task_done()
 
@@ -704,7 +704,7 @@ def setupSegment_md(filename,xmlparser,lwtparser,debug):
     segment_md = ldbd.LIGOMetadata(xmlparser,lwtparser)
 
     #if debug:
-    #    print "Inserting file %s." % filename
+    #    print("Inserting file %s." % filename)
     fh=open(filename,'r')
     xmltext = fh.read()
     fh.close()
@@ -765,7 +765,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
 
     # This next bunch of code is specific to a given file:
     if len(filenames)<1:
-        print "Empty file list sent to InsertMultipleDQXMLFileThreaded"
+        print("Empty file list sent to InsertMultipleDQXMLFileThreaded")
         raise ValueError
     for filename in filenames:
     
@@ -778,7 +778,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         for j in range(len(segment_md.table['segment_definer']['stream'])):
             flag_versions_numbered[j] = {}
             for i,entry in enumerate(segment_md.table['segment_definer']['orderedcol']):
-              #print j,entry,segment_md.table['segment_definer']['stream'][j][i]
+              #print(j,entry,segment_md.table['segment_definer']['stream'][j][i])
               flag_versions_numbered[j][entry] = segment_md.table['segment_definer']['stream'][j][i]
         
         
@@ -802,7 +802,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             # Now we're going to assign elements to process_dict[process_id]
             process_dict[temp_process_id] = {}
             for i,entry in enumerate(segment_md.table['process']['orderedcol']):
-                #print j,entry,segment_md.table['process']['stream'][j][i]
+                #print(j,entry,segment_md.table['process']['stream'][j][i])
                 process_dict[temp_process_id][entry] = segment_md.table['process']['stream'][j][i]
                 # Note that the segment_md.table['process']['stream'][0] looks like this:
                 #0 program SegGener
@@ -905,7 +905,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         for j in range(len(segment_md.table['segment_summary']['stream'])):
             #flag_versions_numbered[j] = {}
             seg_def_index = segment_md.table['segment_summary']['orderedcol'].index('segment_def_id')
-            #print "associated seg_def_id is: "+ segment_md.table['segment_summary']['stream'][j][seg_def_index]
+            #print("associated seg_def_id is: "+ segment_md.table['segment_summary']['stream'][j][seg_def_index])
             (ifo,name,version) = temp_id_to_flag_version[segment_md.table['segment_summary']['stream'][j][seg_def_index]]
             seg_sum_index = segment_md.table['segment_summary']['orderedcol'].index('segment_sum_id')
             # Unneeded:
@@ -982,7 +982,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
                     insert_history_dict['insertion_metadata']['comment'] = '/dq/'+'/'.join([str(ifo),str(name),str(version)])  # FIX make dq a constant string in case we ever change it
                 else:
                     insert_history_dict['insertion_metadata']['uri'] = '/dq/'+'/'.join([str(ifo),str(name),str(version)])  # FIX make dq a constant string in case we ever change it
-                #print ifo,name,version
+                #print(ifo,name,version)
                 insert_history_dict['insertion_metadata']['timestamp'] = _UTCToGPS(time.gmtime())
                 insert_history_dict['insertion_metadata']['auth_user']=process.get_username()
                 #if hackDec11:
@@ -1000,8 +1000,8 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             for j in range(len(segment_md.table['segment']['stream'])):
                 #flag_versions_numbered[j] = {}
                 seg_def_index = segment_md.table['segment']['orderedcol'].index('segment_def_id')
-                #print "associated seg_def_id is: "+ 
-                #    segment_md.table['segment']['stream'][j][seg_def_index]
+                #print("associated seg_def_id is: "+
+                #    segment_md.table['segment']['stream'][j][seg_def_index])
                 (ifo,name,version) = temp_id_to_flag_version[segment_md.table['segment']['stream'][j][seg_def_index]]
                 #seg_sum_index = segment_md.table['segment']['orderedcol'].index('segment_sum_id')
                 start_time_index = segment_md.table['segment']['orderedcol'].index('start_time')
@@ -1013,9 +1013,9 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         except KeyError:
             logger.info("No segment table for this file: %s" % filename)
             if debug:
-                print "No segment table for this file: %s" % filename
+                print("No segment table for this file: %s" % filename)
         except:
-            print "Unexpected error:", sys.exc_info()[0]
+            print("Unexpected error:", sys.exc_info()[0])
             raise
 
     for i in flag_versions.keys():
@@ -1034,12 +1034,12 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             #i.flagDict
             url=i.buildURL(server)
             if debug:
-                print url
+                print(url)
                 logger.debug("json.dumps(i.flagDict):")
                 logger.debug("%s"%json.dumps(i.flagDict))
             #if hackDec11:
             #    if len(i.active)==0:
-            #        print "No segments for this url"
+            #        print("No segments for this url")
             #        continue
             q.put(i)
         q.join()
@@ -1050,21 +1050,21 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             url=i.buildURL(server)
             if debug:
                 logger.debug("Url for the following data: %s" % url)
-                #print url
+                #print(url)
                 logger.debug("json.dumps(i.flagDict):")
                 logger.debug("%s"%json.dumps(i.flagDict))
             #if hackDec11:
             #    if len(i.active)==0:
-            #        print "No segments for this url"
+            #        print("No segments for this url")
             #        continue
             patchWithFailCases(i,url,debug,logger,testing_options)
 
     if debug:
         logger.debug("If we made it this far, no errors were encountered in the inserts.")
-        #print "If we made it this far, no errors were encountered in the inserts."
+        #print("If we made it this far, no errors were encountered in the inserts.")
     ### Fix!!! Improvement: Should be more careful about error handling here.
     if debug:
         t2=time.time()
         logger.debug("Time elapsed for file %s = %d." % (filename,t2-t1))
-        #print "Time elapsed for file %s = %d." % (filename,t2-t1)
+        #print("Time elapsed for file %s = %d." % (filename,t2-t1))
     return True

--- a/dqsegdb/clientutils.py
+++ b/dqsegdb/clientutils.py
@@ -12,6 +12,9 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
 import sys
 import math
 import os
@@ -174,8 +177,8 @@ def calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=None):
             active_segments.coalesce()
             active_results[version]=active_segments
             if debug:
-                print "Active results for version %d" % version
-                print active_results[version]
+                print("Active results for version %d" % version)
+                print(active_results[version])
             # Now I have 2 dictionaries of known and active segments with versions as keys in case I want/need them later...
             # This next step might seem a bit confusing:
             # We need to take the active segments for this version only during times that were not known by higher segment versions
@@ -183,7 +186,7 @@ def calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=None):
             total_active_list |= (total_query_time-total_known_list)&known_segments&active_segments
             if debug:
                 import pdb
-                print "Running pdb to see what is in total_active_list"
+                print("Running pdb to see what is in total_active_list")
                 pdb.set_trace()
             total_active_list.coalesce()
             # The S6 clients want to know about the range of times affected by a given version explicitly, so those are calculated here:
@@ -389,7 +392,7 @@ def run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, in
         spec = included.split(':')
 
         if len(spec) < 2 or len(spec) > 3:
-            print >>sys.stderr, "Included segements must be of the form ifo:name:version or ifo:name:*"
+            print("Included segements must be of the form ifo:name:version or ifo:name:*", file=sys.stderr)
             sys.exit(1)
 
         ifo     = spec[0]
@@ -397,7 +400,7 @@ def run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, in
         if len(spec) is 3 and spec[2] is not '*':
             version = int(spec[2])
             if version < 1:
-                print >>sys.stderr, "Segment version numbers must be greater than zero"
+                print("Segment version numbers must be greater than zero", file=sys.stderr)
                 sys.exit(1)
         else:
             version = '*'
@@ -422,7 +425,7 @@ def run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, in
             spec = excluded.split(':')
 
             if len(spec) < 2:
-                print >>sys.stderr, "Excluded segements must be of the form ifo:name:version or ifo:name:*"
+                print("Excluded segements must be of the form ifo:name:version or ifo:name:*", file=sys.stderr)
                 sys.exit(1)
 
             ifo     = spec[0]
@@ -449,8 +452,8 @@ def run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, in
 
     # and store the segments
     segmentdb_utils.add_to_segment(doc, process_id, seg_def_id, found_segments)
-    print "Made it to the end of the query code"
-    print doc
+    print("Made it to the end of the query code")
+    print(doc)
            
 
 

--- a/dqsegdb/jsonhelper.py
+++ b/dqsegdb/jsonhelper.py
@@ -157,20 +157,20 @@ class PatchFlagVersion(FlagVersion):
         first=True
         debug=False
         if debug:
-            print "Printing insert history"
-            print self.insert_history
-            print "length:"
-            print len(self.insert_history)
+            print("Printing insert history")
+            print(self.insert_history)
+            print("length:")
+            print(len(self.insert_history))
 
         for i in self.insert_history:
             if debug:
-                print "self.insert_history element:"
-                print i
+                print("self.insert_history element:")
+                print(i)
             if first:
                 final_history.append(i)
                 first = False
                 if debug:
-                    print "first!"
+                    print("first!")
             else:
                 process_name=i['process_metadata']['name']
                 process_pid=i['process_metadata']['pid']
@@ -178,25 +178,25 @@ class PatchFlagVersion(FlagVersion):
                 matched=False
                 for j in final_history:
                     if debug:
-                        print "printing i"
-                        print i
-                        print "printing j for comparison"
-                        print j
+                        print("printing i")
+                        print(i)
+                        print("printing j for comparison")
+                        print(j)
                     if process_name==j['process_metadata']['name'] and process_pid==j['process_metadata']['pid'] and process_uid==j['process_metadata']['uid']:  # FIX!!! Should we sort these by time order and then match end time of file_history element to start_time of insert_history element?
                         j['insertion_metadata']['insert_data_stop']=max(j['insertion_metadata']['insert_data_stop'],i['insertion_metadata']['insert_data_stop'])
                         j['insertion_metadata']['insert_data_start']=min(j['insertion_metadata']['insert_data_start'],i['insertion_metadata']['insert_data_start'])
                         if debug:
-                            print "i matched j"
+                            print("i matched j")
                             matched=True
                     else:
                         if debug:
-                            print "i didn't match j"
+                            print("i didn't match j")
                 if not matched:
                     final_history.append(i)
         if debug:
-            print "Printing final history:"
-            print final_history
-            print len(final_history)
+            print("Printing final history:")
+            print(final_history)
+            print(len(final_history))
         self.insert_history=final_history
 
 

--- a/dqsegdb/urifunctions.py
+++ b/dqsegdb/urifunctions.py
@@ -12,6 +12,9 @@
 # 
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
 import warnings
 import sys
 import httplib
@@ -80,37 +83,37 @@ def getDataUrllib2(url,timeout=900,logger=None,warnings=True):
         logger.debug("Beginning url call: %s" % url)
     try:
         if urlparse.urlparse(url).scheme == 'https':
-            #print "attempting to send https query"
-            #print certfile
-            #print keyfile
+            #print("attempting to send https query")
+            #print(certfile)
+            #print(keyfile)
             opener=urllib2.build_opener(HTTPSClientAuthHandler)
-            #print opener.handle_open.items()
+            #print(opener.handle_open.items())
             request = urllib2.Request(url)
             output=opener.open(request)
         else:
-            #print "attempting to send http query"
+            #print("attempting to send http query")
             output=urllib2.urlopen(url)
     except urllib2.HTTPError,e:
-        #print "Warnings setting FIX:"
-        #print warnings
+        #print("Warnings setting FIX:")
+        #print(warnings)
         if warnings:
             handleHTTPError("GET",url,e)
         else:
             handleHTTPError("QUIET",url,e)
 
-        ##print e.read()
-        #print "Warning: Issue accessing url: %s" % url
-        #print "Code: "
-        #print e.code
-        #print e.msg
+        ##print(e.read())
+        #print("Warning: Issue accessing url: %s" % url)
+        #print("Code: ")
+        #print(e.code)
+        #print(e.msg)
         ##import pdb
         ##pdb.set_trace()
-        ##print e.reason
-        ##print url
-        #print "May be handled cleanly by calling instance: otherwise will result in an error."
+        ##print(e.reason)
+        ##print(url)
+        #print("May be handled cleanly by calling instance: otherwise will result in an error.")
         raise
     except urllib2.URLError,e:
-        #print e.read()
+        #print(e.read())
         warnings.warn("Issue accesing url: %s; Reason: %s" % (url,str(e.reason)))
         try:
             type, value, traceback_stack = sys.exc_info()
@@ -254,23 +257,23 @@ def putDataUrllib2(url,payload,timeout=900,logger=None):
         urlreturned = opener.open(request)
     except urllib2.HTTPError,e:
         handleHTTPError("PUT",url,e)
-        ##print e.read()
+        ##print(e.read())
         #if int(e.code)==404:
-        #    print "Flag does not exist in database yet for url: %s" % url
+        #    print("Flag does not exist in database yet for url: %s" % url)
         #else:
-        #    print "Warning: Issue accessing url: %s" % url
-        #    print "Code: "
-        #    print e.code
-        #    print "Message: "
-        #    print e.msg
-        #    #print e.reason
-        #    #print url
-        #    print "May be handled cleanly by calling instance: otherwise will result in an error."
-        ##print e.reason
-        ##print urlreturned
+        #    print("Warning: Issue accessing url: %s" % url)
+        #    print("Code: ")
+        #    print(e.code)
+        #    print("Message: ")
+        #    print(e.msg)
+        #    #print(e.reason)
+        #    #print(url)
+        #    print("May be handled cleanly by calling instance: otherwise will result in an error.")
+        ##print(e.reason)
+        ##print(urlreturned)
         raise
     except urllib2.URLError,e:
-        #print e.read()
+        #print(e.read())
         warnmsg="Warning: Issue accessing url: %s" % url
         warnmsg+="; "
         warnmsg+=str(e.reason)
@@ -300,7 +303,7 @@ def patchDataUrllib2(url,payload,timeout=900,logger=None):
         opener=urllib2.build_opener(HTTPSClientAuthHandler)
     else:
         opener = urllib2.build_opener(urllib2.HTTPHandler)
-    #print opener.handle_open.items()            
+    #print(opener.handle_open.items())
     request = urllib2.Request(url, data=payload)
     request.add_header('Content-Type', 'JSON')
     request.get_method = lambda: 'PATCH'
@@ -310,16 +313,16 @@ def patchDataUrllib2(url,payload,timeout=900,logger=None):
         urlreturned = opener.open(request)
     except urllib2.HTTPError,e:
         handleHTTPError("PATCH",url,e)
-        ##print e.read()
-        #print "Warning: Issue accessing url: %s" % url
-        #print "Code: "
-        #print e.code
-        ##print e.reason
-        ##print url
-        #print "May be handled cleanly by calling instance: otherwise will result in an error."
+        ##print(e.read())
+        #print("Warning: Issue accessing url: %s" % url)
+        #print("Code: ")
+        #print(e.code)
+        ##print(e.reason)
+        ##print(url)
+        #print("May be handled cleanly by calling instance: otherwise will result in an error.")
         raise
     except urllib2.URLError,e:
-        #print e.read()
+        #print(e.read()
         warnmsg="Warning: Issue accessing url: %s" % url
         warnmsg+="; "
         warnmsg+=str(e.reason)
@@ -339,15 +342,15 @@ def handleHTTPError(method,url,e):
         warnings.warn("Warning: Issue accessing url: %s" % url)
         warnings.warn("Code: %s" % str(e.code)) 
         warnings.warn("Message: %s" % str(e.msg))
-        #print e.reason
-        #print url
+        #print(e.reason)
+        #print(url)
         warnings.warn("May be handled cleanly by calling instance: otherwise will result in an error.")
     else:
         if method == "PUT" or method == "PATCH":
             warnings.warn("Info: Flag does not exist in database yet for url: %s" % url)
         elif method == "GET":
             warnings.warn("Warning: Issue accessing url: %s" % url)
-            #print "yo! FIX!!!"
+            #print("yo! FIX!!!")
             warnings.warn("Code: %s" % str(e.code))
             warnings.warn("Message: %s" % str(e.msg))
             warnings.warn("May be handled cleanly by calling instance: otherwise will result in an error.")
@@ -424,7 +427,7 @@ Could not find a valid proxy credential.
 LIGO users, please run 'ligo-proxy-init' and try again.
 Others, please run 'grid-proxy-init' and try again.
 """
-    print >>sys.stderr, msg
+    print(msg, file=sys.stderr)
 
 def validateProxy(path):
     """
@@ -438,7 +441,7 @@ def validateProxy(path):
         proxy = M2Crypto.X509.load_cert(path)
     except Exception, e:
         msg = "Unable to load proxy from path %s : %s" % (path, e)
-        print >>sys.stderr, msg
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
     # make sure the proxy is RFC 3820 compliant
@@ -473,7 +476,7 @@ Your proxy certificate is expired.
 Please generate a new proxy certificate and
 try again.
 """
-        print >>sys.stderr, msg
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
     # return True to indicate validated proxy


### PR DESCRIPTION
This PR replaces all instances of the python 2.x `print` statement, with the python 3.x `print()` function, using the `from __future__ import print_function` where required.

This should save time in the future when python-3.x is a requirement.
