### PR TITLE
Removed trailing whitespace wherever I could find it

### DIFF
--- a/bin/ligolw_arbitrary_publish_generation.py
+++ b/bin/ligolw_arbitrary_publish_generation.py
@@ -1,30 +1,30 @@
 #!/usr/bin/env python
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import errno

--- a/bin/ligolw_arbitrary_publish_generation.py
+++ b/bin/ligolw_arbitrary_publish_generation.py
@@ -180,7 +180,7 @@ if site=='CIT' and S6:
         input_directory="/archive/frames/online/DQ/V1"
     elif interferometer=="H" or interferometer=="L":
         input_directory="/archive/frames/dmt/L${inf}O/triggers/DQ_Segments"
-elif site=='CIT': 
+elif site=='CIT':
     input_directory="/archive/frames/dmt/ER5/DQ/${inf}1" #assume ER5
 elif site=='SYR' and S6:
     if interferometer=="V":
@@ -224,13 +224,13 @@ do
   %(comment_cp)scp %(template_state_file)s %(run_dir)s/var/spool/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.xml
   rm -f /usr1/%(user_name)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log
   /usr/bin/env python -W ignore::DeprecationWarning %(publish_executable)s --segment-url %(server)s --state-file=%(run_dir)s/var/spool/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.xml --pid-file=%(run_dir)s/var/run/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.pid --log-file=/usr1/%(user_name)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log --input-directory=%(input_directory)s --log-level %(log_level)s -m %(files_per_publish)s -c %(threading)s -b ${start} -e ${end} -o ${offset} %(synch_command)s
-  cp /usr1/%(user_name)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log %(log_file_dir)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log 
+  cp /usr1/%(user_name)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log %(log_file_dir)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log
   rm -f /usr1/%(user_name)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log) &
 done
 for i in {0..%(repeat_runs)s}
 do
   while [ ! -f %(log_file_dir)s/${inf}-DQ_Segments_S6_${start}_${end}_${offset}.log ]
-  do 
+  do
     sleep 2
   done
 done

--- a/bin/ligolw_dq_query_dqsegdb
+++ b/bin/ligolw_dq_query_dqsegdb
@@ -31,7 +31,7 @@ Provides tools to query the DQSEGDB segment database egarding the
 set of flags defined/active at or near a given time:
 
 
-The --report option prints an extensive query of the database for (a) given gps time(s). For the flags which were defined, it reports all active segments within the time span provided as input.  
+The --report option prints an extensive query of the database for (a) given gps time(s). For the flags which were defined, it reports all active segments within the time span provided as input.
   * What is the status of all DQ flags at this time? ligolw_dq_query --report
   * In a custom window (default is +/-10 seconds? ligolw_dq_query --start-pad --end-pad
 """
@@ -103,7 +103,7 @@ def parse_command_line():
     parser.add_option("-a", "--active-only",  action = "store_true", help = "Only report about active segments in specified window, excludes report of known times for flags.")
     parser.add_option("-f", "--tom-formatting", action = "store_true", help = "Tom Dent requested formatting option: condensed output into single lines.")
     parser.add_option("-b", "--seperate-good-from-bad", action = "store_true", help = "Seperates flags marked by the database as being active when the ifo is in a bad state from those that are active when the ifo is in a good state.")
-   
+
     options, time = parser.parse_args()
 
     # Make sure we have required arguments
@@ -150,7 +150,7 @@ def get_full_name(ifo, name, version):
 #
 #    # I'm not happy with the fact that this is done with four separate
 #    # queries.  However it is possible that, say, there won't be a segment
-#    # after the given time in which case 
+#    # after the given time in which case
 #    #
 #    #   select MAX(end_time), MIN(start_time)
 #    #   where end_time < given time and start_time > given time
@@ -170,7 +170,7 @@ def get_full_name(ifo, name, version):
 #             FROM segment_definer, segment
 #             WHERE segment_definer.segment_def_id = segment.segment_def_id
 #             AND %d BETWEEN segment.start_time AND segment.end_time
-#             %s """ % (tm, segment_clause)) 
+#             %s """ % (tm, segment_clause))
 #
 #        in_times = {}
 #        for ifo, name, version, start_time, end_time in rows:
@@ -187,8 +187,8 @@ def get_full_name(ifo, name, version):
 #                WHERE segment_definer.segment_def_id = segment.segment_def_id
 #                AND segment.end_time < %d %s
 #                GROUP BY segment_definer.ifos, segment_definer.name, segment_definer.version""" % (tm, segment_clause))
-#           
-#           
+#
+#
 #            for ifo, name, version, end_time in rows:
 #                full_name = get_full_name(ifo, name, version)
 #                out_times[full_name] = ['%d)' % end_time, '[now']
@@ -225,7 +225,7 @@ def get_full_name(ifo, name, version):
 #        AND   segment_definer.segment_def_id = segment.segment_def_id
 #        AND """ + time_clause + segment_clause)
 #
-#    
+#
 #    distinct_names = []
 #    distinct_rows = []
 #    for x in rows:
@@ -290,15 +290,15 @@ def get_full_name(ifo, name, version):
 #
 
 if __name__ == '__main__':
-    options, database_location, time  = parse_command_line()    
+    options, database_location, time  = parse_command_line()
 
     o=urlparse.urlparse(options.segment_url)
     protocol=o.scheme
     server=o.netloc
-    
+
     start_pad = 0
     end_pad   = 0
-    
+
     if len(time) > 1:
         raise ValueError("Please provide one central gps time for your query.")
     else:
@@ -350,7 +350,7 @@ if __name__ == '__main__':
                 active_results[flag_string].append(segments.segment(start_time,end_time))
                 if i['metadata']['active_indicates_ifo_badness']!=True:
                     active_results_not_bad[flag_string].append(segments.segmentlist([segments.segment(start_time,end_time)]))
-    
+
     if not options.tom_formatting:
         tom=False
     else:
@@ -440,10 +440,10 @@ if __name__ == '__main__':
         if options.seperate_good_from_bad:
             print "Flags marked as active means ifo operating well, that are defined but inactive in this period.  These should be considered as possible vetoes!"
             for i in known_dict['results']:
-                ifo=i['ifo'] 
-                name=i['name'] 
-                version=str(i['version']) 
-                flag_string=":".join([ifo,name,version]) 
+                ifo=i['ifo']
+                name=i['name']
+                version=str(i['version'])
+                flag_string=":".join([ifo,name,version])
                 if flag_string not in active_results:
                     if i['metadata']['active_indicates_ifo_badness']!=True:
                         if tom==True:
@@ -470,6 +470,6 @@ if __name__ == '__main__':
         fh=open(options.output_file,'w')
         fh.write(json_string_out)
         fh.close()
-        
+
 
 

--- a/bin/ligolw_dq_query_dqsegdb
+++ b/bin/ligolw_dq_query_dqsegdb
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 ## Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb
@@ -16,7 +16,7 @@
 
 """
 Publishing client used to publish DQMXML (usually produced by DMT) from a set
-of directories to the DQSEGDB server.  This publisher supports grouping 
+of directories to the DQSEGDB server.  This publisher supports grouping
 multiple input files together, and then pushing data to the database either
 one flag:version at a time or pushing data in a threaded manner.
 
@@ -25,7 +25,7 @@ Also supports a start time and end time argument to restrict the range of input 
 Please see Python help documentation for all input arguments.
 
 Example call to function:
-    
+
 ligolw_publish_threaded_dqxml_dqsegdb --segment-url http://slwebtest.virgo.infn.it --state-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/spool/L-DQ_Segments_long_test.xml --pid-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/run/L-DQ_Segments.pid --log-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/log/L-DQ_Segments.log --input-directory=/archive/frames/dmt/ER4/DQ/L1 --log-level DEBUG -m 60 -c 20 -e 105819443
 """
 
@@ -123,11 +123,11 @@ if not options.segment_url:
 #old   msg = myClient.ping()
 #old   print msg
 #old   sys.exit(0)
-#old 
+#old
 if not options.state_file and not options.segments_file:
   raise ValueError, "missing argument --state-file or --segments-file"
 if options.state_file and options.segments_file:
-  raise ValueError, "incompatible arguments --state-file and --segments-file"  
+  raise ValueError, "incompatible arguments --state-file and --segments-file"
 if not options.pid_file:
   raise ValueError, "missing argument --pid-file"
 if not options.input_directory:
@@ -136,7 +136,7 @@ if not options.log_file:
   raise ValueError, "missing argument --log-file"
 if options.log_level=="DEBUG":
   local_debug=True
-else: 
+else:
   local_debug=False
 
 # check if a valid lock file already exists, and create one if not
@@ -200,7 +200,7 @@ try:
   if options.end_time:
       ending_time=segments.segmentlist([segments.segment(0,int(options.end_time))])
       pending_segments&=ending_time
-      
+
   logger.info("pending segments = %s" % str(pending_segments))
   pending_files = lal.Cache()
   # make a list of the files that need to be inserted
@@ -298,14 +298,14 @@ try:
             if result:
               logger.debug("published remaining segments before interrupt: %s" % str(grouped_segments))
               published_segments |= grouped_segments
-            #die_now = True unneeded because there is no loop here, we are just cleaning up 
+            #die_now = True unneeded because there is no loop here, we are just cleaning up
           except Exception, e:
             logger.error("failed to publish %s (%s)" % (infiles, str(e)))
           else:
             if result:
               logger.debug("published remaining segments %s" % str(grouped_segments))
               published_segments |= grouped_segments
-            else: 
+            else:
               logger.debug("Failed to publish segments in group: %s" % str(grouped_segments))
 
 

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb
@@ -1,16 +1,16 @@
 #!/usr/bin/python
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
@@ -1,30 +1,30 @@
 #!/usr/bin/python
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
@@ -32,25 +32,25 @@
 #
 #
 # Copyright (C) 2013 Ryan Fisher
-# 
+#
 # This is part of the Grid LSC User Environment (GLUE)
-# 
+#
 # GLUE is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
 # Foundation, either version 3 of the License, or (at your option) any later
 # version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
 # more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 Publishing client used to publish DQMXML (usually produced by DMT) from a set
-of directories to the DQSEGDB server.  This publisher supports grouping 
+of directories to the DQSEGDB server.  This publisher supports grouping
 multiple input files together, and then pushing data to the database either
 one flag:version at a time or pushing data in a threaded manner.
 
@@ -59,7 +59,7 @@ Also supports a start time and end time argument to restrict the range of input 
 Please see Python help documentation for all input arguments.
 
 Example call to function:
-    
+
 ligolw_publish_threaded_dqxml_dqsegdb --segment-url http://slwebtest.virgo.infn.it --state-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/spool/L-DQ_Segments_long_test.xml --pid-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/run/L-DQ_Segments.pid --log-file=/home/rfisher/DQSEGDB/DQSEGDBClient/var/log/L-DQ_Segments.log --input-directory=/archive/frames/dmt/ER4/DQ/L1 --log-level DEBUG -m 60 -c 20 -e 105819443
 """
 
@@ -168,11 +168,11 @@ if not options.segment_url:
 #old   msg = myClient.ping()
 #old   print msg
 #old   sys.exit(0)
-#old 
+#old
 if not options.state_file and not options.segments_file:
   raise ValueError, "missing argument --state-file or --segments-file"
 if options.state_file and options.segments_file:
-  raise ValueError, "incompatible arguments --state-file and --segments-file"  
+  raise ValueError, "incompatible arguments --state-file and --segments-file"
 if not options.pid_file:
   raise ValueError, "missing argument --pid-file"
 if not options.input_directory:
@@ -181,7 +181,7 @@ if not options.log_file:
   raise ValueError, "missing argument --log-file"
 if options.log_level=="DEBUG":
   local_debug=True
-else: 
+else:
   local_debug=False
 
 # check if a valid lock file already exists, and create one if not
@@ -235,7 +235,7 @@ try:
   if options.end_time:
       ending_time=segments.segmentlist([segments.segment(0,int(options.end_time))])
       pending_segments&=ending_time
-      
+
   logger.info("pending segments = %s" % str(pending_segments))
   pending_files = lal.Cache()
   # make a list of the files that need to be inserted
@@ -334,14 +334,14 @@ try:
         if result:
           logger.debug("published remaining segments before interrupt: %s" % str(grouped_segments))
           published_segments |= grouped_segments
-        #die_now = True unneeded because there is no loop here, we are just cleaning up 
+        #die_now = True unneeded because there is no loop here, we are just cleaning up
       except Exception, e:
         logger.error("failed to publish %s (%s)" % (infiles, str(e)))
       else:
         if result:
           logger.debug("published remaining segments %s" % str(grouped_segments))
           published_segments |= grouped_segments
-        else: 
+        else:
           logger.debug("Failed to publish segments in group: %s" % str(grouped_segments))
 
 

--- a/bin/ligolw_segment_insert_dqsegdb
+++ b/bin/ligolw_segment_insert_dqsegdb
@@ -32,7 +32,7 @@ import exceptions
 import binascii
 from optparse import OptionParser
 from dqsegdb import apicalls
-from dqsegdb import jsonhelper 
+from dqsegdb import jsonhelper
 import json
 
 try:
@@ -57,9 +57,9 @@ try:
   from glue.segmentdb import segmentdb_utils
   from glue.ligolw import table
   from glue.ligolw import lsctables
-  from glue.ligolw import ligolw 
+  from glue.ligolw import ligolw
   from glue.ligolw.utils import process
-  from glue.ligolw import types as ligolwtypes 
+  from glue.ligolw import types as ligolwtypes
 except ImportError, e:
   print >> sys.stderr, """
 Error: unable to import modules from glue.
@@ -89,7 +89,7 @@ except:
 ##################################################################
 def parse_command_line():
   parser = OptionParser()
-  
+
   parser.add_option("-p", "--ping", action = "store_true", default = None, help = "Ping the target server")
   parser.add_option("-t", "--segment-url", action = "store", metavar = "URL", default = None, help = "Users have to specify protocol 'https://' for a secure connection in the segment database url. For example, '--segment-url=https://segdb.ligo.caltech.edu'. No need to specify port number'.")
   parser.add_option("-o", "--output", action = "store", metavar = "FILE", default = None,help = "Write segments to FILE rather than the segment database")
@@ -107,13 +107,13 @@ def parse_command_line():
   parser.add_option("-S", "--summary-file", action = "store", metavar = "FILE", default = None, help = "Read the segment_summary rows from FILE. This should be a file containing the gps start and end times that the flag was defined (i.e. the union of on and off)")
   parser.add_option("-G", "--segment-file", action = "store", metavar = "FILE", default = None,  help = "Read the segment rows from FILE. This should containin the gps start and end times when the flag was active")
   parser.add_option("-B", "--active-indicates-ifo-goodness", action = "store_true", default = False,  help = "Sets the variable in the database to indicate that the flag is active when something is good in the ifo state. Default is False, so flags normally indicate something is wrong.")
-  
-  
+
+
   return parser.parse_args()
-  
-    
+
+
 (options, args) = parse_command_line()
-    
+
 # Make sure all necessary command line arguments are properly given
 errmsg = ""
 if not options.segment_url:
@@ -152,7 +152,7 @@ if options.active_indicates_ifo_goodness:
 else:
   use_xml=True
   active_indicates_ifo_goodness=False # default
-  
+
 if len(errmsg) and not options.ping:
   print >> sys.stderr, errmsg
   print >> sys.stderr, "Run\n    %s --help\nfor more information." % sys.argv[0]
@@ -162,7 +162,7 @@ if len(errmsg) and not options.ping:
 #o ########################################################################
 #o # open connection to LDBD(W)Server
 #o myClient = segmentdb_utils.setup_database(options.segment_url)
-#o 
+#o
 #o if options.ping:
 #o    try:
 #o      print myClient.ping()
@@ -213,23 +213,23 @@ lwtparser = ldbd.LIGOLwParser()
 segment_md = ldbd.LIGOMetadata(xmlparser,lwtparser)
 
 ########################################################################
-# Construct local table process, process_params and segment_definer 
+# Construct local table process, process_params and segment_definer
 ########################################################################
-# Table process and process_params will be popullated by calling the 
+# Table process and process_params will be popullated by calling the
 # process/process_params utility
 
 #myClient = segmentdb_utils.setup_database(options.segment_url)
 doc = ligolw.Document()
 doc.appendChild(ligolw.LIGO_LW())
 
-ligolwtypes.FromPyType[type(True)] = ligolwtypes.FromPyType[type(0)] 
+ligolwtypes.FromPyType[type(True)] = ligolwtypes.FromPyType[type(0)]
 
 process_id = process.register_to_xmldoc(doc, PROGRAM_NAME, options.__dict__,
              version = __version__,
              cvs_entry_time = __date__, comment = 'ligolw_segment_insert_dqsegdb client insert or append').process_id
 
 ##########################################################################
-#             Process segment-file and summary-file 
+#             Process segment-file and summary-file
 ##########################################################################
 # create the total time interval and storage for the active segments
 intervals = segments.segmentlist()
@@ -238,8 +238,8 @@ active_segments = segments.segmentlist()
 #-----------------Check version and type existence-------------------------
 
 # Query server for current highest version and flag name
-o=urlparse.urlparse(options.segment_url)        
-protocol=o.scheme        
+o=urlparse.urlparse(options.segment_url)
+protocol=o.scheme
 server=o.netloc
 
 version=int(options.version)
@@ -287,7 +287,7 @@ else:
 #data_dict,query_url1=apicalls.dqsegdbQueryTimeless(protocol,server,options.ifos,options.name,options.version,include_list_string='known,metadata')
 #maxEndTime=max([i[1] for i in data_dict['known']])
 
-### Fix!!! (future upgrade):  If I'm going to allow an xml file input, I'm going to have to do the following check on the xml file instead, implement that when I allow that.  
+### Fix!!! (future upgrade):  If I'm going to allow an xml file input, I'm going to have to do the following check on the xml file instead, implement that when I allow that.
 
 #-----------------Check summary-file---------------------------------
 # get and check the summary intervals to be inserted
@@ -344,7 +344,7 @@ for line in fh.readlines():
      print "Invalid segment is %s" % str(seg_line)
      sys.exit(1)
   # make sure gps time is 9 digits
-  #if (len(seg_line[0]) != 9 or len(seg_line[1])!=9): 
+  #if (len(seg_line[0]) != 9 or len(seg_line[1])!=9):
   #   print "\nERROR: gps time must be 9 digits"
   #   print "Invalid segment in your --segment-file row number: %d" % line_no
   #   print "Invalid segment is %s" % str(seg_line)
@@ -356,7 +356,7 @@ for line in fh.readlines():
     print "Invalid segment is %s" % str(seg_line)
     sys.exit(1)
   # make sure segment falls in the summary  intervals specified in the --summary-file
-  this_seg = segments.segment(int(seg_line[0]),int(seg_line[1])) 
+  this_seg = segments.segment(int(seg_line[0]),int(seg_line[1]))
   if this_seg not in intervals:
     print "\nERROR: segment cannot fall outside of the summary intervals specified in your --summary-file"
     print "Invalid segment in your --segment-file row number: %d" % line_no
@@ -408,7 +408,7 @@ if options.insert or options.append:
 
       segment_table.append(segment)
 
-    
+
     #-------------- create local segment_summary table ------------#
     seg_sum_table = lsctables.New(lsctables.SegmentSumTable, columns = [
                     'segment_sum_id', 'process_id', 'segment_def_id', 'start_time', 'end_time', 'comment'])
@@ -417,14 +417,14 @@ if options.insert or options.append:
     for this_sum in intervals:
        segment_summary = lsctables.SegmentSum()
        seg_sum_id = seg_sum_table.get_next_id()
-       
+
        segment_summary.segment_sum_id = seg_sum_id
        segment_summary.process_id = process_id
        segment_summary.segment_def_id = seg_def_id
        segment_summary.start_time = this_sum[0]
        segment_summary.end_time = this_sum[1]
        segment_summary.comment = options.comment
- 
+
        seg_sum_table.append(segment_summary)
 
     fake_file = StringIO.StringIO()
@@ -441,7 +441,7 @@ if options.insert or options.append:
         print "Writing to temporary file, then calling callInsertMultipleDQXMLThreaded"
       filepath='/tmp/ligolw_segment_insert_'+str(time.time())+'.xml'
       if not debug:
-        atexit.register(del_file,filepath) # 
+        atexit.register(del_file,filepath) #
       fp = open(filepath,'w')
       fp.write(fake_file.getvalue())
       fp.close()
@@ -456,7 +456,7 @@ if options.insert or options.append:
       #    sys.exit()
   else: # Direct to JSON
     ## Result JSON should look like this:
-    ''' 
+    '''
     {
        "name":"DCH-RYAN_TEST_MAY192016",
        "insert_history":[
@@ -530,14 +530,14 @@ if options.insert or options.append:
     '''
     # Ok, first need to build the dictionary object:
     # flag_versions[(ifo,name,version)] = InsertFlagVersion(ifo,name,version)
-    
+
     # new_seg_summary = segments.segmentlist([segments.segment(start_time,end_time)])
     # flag_versions[(ifo,name,version)].appendKnown(new_seg_summary)
-    
+
     # flag_versions[(ifo,name,version)].flag_description=str(flag_versions_numbered[i]['comment'])
     # flag_versions[(ifo,name,version)].provenance_url=seg_sum_comment
     # flag_versions[i].flag_version_comment=process_dict[pid]['process_comment']
-    
+
     # insert_history_dict = {}
     # process_name=i['process_metadata']['name']
     # process_pid=i['process_metadata']['pid']
@@ -546,7 +546,7 @@ if options.insert or options.append:
     # insert_history_dict['insertion_metadata'] = {}
     # insert_history_dict['insertion_metadata']['insert_data_stop'] = stop
     # insert_history_dict['insertion_metadata']['insert_data_start'] = start
-    # insert_history_dict['insertion_metadata']['timestamp'] = _UTCToGPS(time.gmtime()) 
+    # insert_history_dict['insertion_metadata']['timestamp'] = _UTCToGPS(time.gmtime())
     # insert_history_dict['insertion_metadata']['auth_user']=process.get_username()
     # insert_history_dict['insertion_metadata']['comment'] = '/dq/'+'/'.join([str(ifo),str(name),str(version)])
     # flag_versions[i].insert_history.append(insert_history_dict)
@@ -554,7 +554,7 @@ if options.insert or options.append:
     # new_seg = segments.segmentlist([segments.segment(start_time,end_time)])
     # flag_versions[(ifo,name,version)].appendActive(new_seg)
     # flag_versions[i].coalesceInsertHistory()
-    
+
     # for i in flag_versions.values():
     #   i.buildFlagDictFromInsertVersion()
     #   url=i.buildURL(server)
@@ -585,7 +585,7 @@ if options.insert or options.append:
     process_dict[PROGRAM_PID]['process_metadata']={}
     process_dict[PROGRAM_PID]['process_metadata']['name'] = PROGRAM_NAME
     process_dict[PROGRAM_PID]['process_metadata']['pid'] = PROGRAM_PID
-    process_dict[PROGRAM_PID]['process_metadata']['uid'] = USER_NAME 
+    process_dict[PROGRAM_PID]['process_metadata']['uid'] = USER_NAME
     arglist=[]
     for i in process.process_params_from_dict(options.__dict__):
         arglist.append(i[0])
@@ -594,13 +594,13 @@ if options.insert or options.append:
         else:
             arglist.append("None")
     process_dict[PROGRAM_PID]['process_metadata']['args'] = arglist  #[i[0],i[2] for i in process.process_params_from_dict(options.__dict__)
-    process_dict[PROGRAM_PID]['process_metadata']['fqdn'] = socket.gethostname() 
+    process_dict[PROGRAM_PID]['process_metadata']['fqdn'] = socket.gethostname()
     process_dict[PROGRAM_PID]['process_metadata']['process_start_timestamp'] = current_time
     insert_history_dict['process_metadata'] = process_dict[PROGRAM_PID]['process_metadata']
     insert_history_dict['insertion_metadata'] = {}
     insert_history_dict['insertion_metadata']['insert_data_start'] = min(min(intervals))
     insert_history_dict['insertion_metadata']['insert_data_stop'] = max(max(intervals))
-    insert_history_dict['insertion_metadata']['timestamp'] = current_time #_UTCToGPS(time.gmtime()) 
+    insert_history_dict['insertion_metadata']['timestamp'] = current_time #_UTCToGPS(time.gmtime())
     insert_history_dict['insertion_metadata']['auth_user']= USER_NAME #process.get_username()
     insert_history_dict['insertion_metadata']['comment'] = '/dq/'+'/'.join([str(options.ifos),str(options.name),str(options.version)])
     flag_version.insert_history.append(insert_history_dict)

--- a/bin/ligolw_segment_insert_dqsegdb
+++ b/bin/ligolw_segment_insert_dqsegdb
@@ -1,16 +1,16 @@
 #!/usr/bin/python
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/bin/ligolw_segment_query_dqsegdb
+++ b/bin/ligolw_segment_query_dqsegdb
@@ -29,11 +29,11 @@
 
 """
 This provides the means to answer several questions posed against either the
-segment database or a collection of DMT XML files.  Output should match 
+segment database or a collection of DMT XML files.  Output should match
 exactly the format returned by S6 style segment database tools.
 
   * What DQ flags exist in the database? ligolw_segment_query --show-types
-  * When was a given DQ flag defined? ligolw_segment_query --query-types 
+  * When was a given DQ flag defined? ligolw_segment_query --query-types
   * When was a given flag active? ligolw_segment_query --query-segments
 * Example: ligolw_segment_query_dqsegdb --segment-url=http://dqsegdb4.phy.syr.edu --query-segments --gps-start-time 987654321 --gps-end-time 987654333 --include-segments="H1:DMT-SCIENCE:1" -o example.xml
 """
@@ -137,14 +137,14 @@ def parse_command_line():
 
     parser.add_option("-S", "--strict-off", metavar = "use_strict", action = "store_true", help = "The default behavior is to truncate segments so that returned segments are entirely in the interval [gps-start-time, gps-end-time).  However if this option is given, the entire non-truncated segment is returned if any part of it overlaps the interval.")
 
-    parser.add_option("-n", "--result-name", metavar = "result_name", default = "RESULT", help = "Name for result segment definer (default = RESULT)") 
+    parser.add_option("-n", "--result-name", metavar = "result_name", default = "RESULT", help = "Name for result segment definer (default = RESULT)")
 
     parser.add_option("-o", "--output-file",   metavar = "output_file", help = "File to which output should be written.  Defaults to stdout.")
     #parser.add_option("-v", "--debug", metavar="debug", help= "Turn on debugging.")
 
     parser.add_option("-l", "--use-s6", metavar="use_s6", action = "store_true", help="Use old s6 style client code.  This is needed to connect to S6 style segdb servers using DB2.  Note that this code is duplicated from the old client, and may become deprecated over time.")
 
-    
+
     options, others = parser.parse_args()
 
     # Make sure we have exactly one thing to do
@@ -152,11 +152,11 @@ def parse_command_line():
     for arg in [options.ping, options.query_types, options.show_types, options.query_segments]:
         if arg:
             count += 1
-            
+
     if count != 1:
         raise ValueError("Exactly one of [ --ping | --show-types | --query-types | --query-segments ] must be provided")
-    
-    
+
+
     # Make sure we have required arguments
     database_location = None
     file_location     = None
@@ -169,10 +169,10 @@ def parse_command_line():
             file_location = options.segment_url[len('file://'):]
         else:
             tmp_dir = tempfile.mkdtemp()
-        
+
             # Grab the part of the name after the last slash
             pos     = options.segment_url[::-1].find('/')
-            fname   = (pos > -1) and options.segment_url[ -1 * pos:] or "dmt.xml" 
+            fname   = (pos > -1) and options.segment_url[ -1 * pos:] or "dmt.xml"
 
             inurl   = urllib.urlopen(options.segment_url)
             outfile = open(tmp_dir + "/" + fname, 'w')
@@ -195,7 +195,7 @@ def parse_command_line():
         file_location = tmp
     else:
         raise ValueError( "One of [ --segment-url | --database | --dmt-files ] must be provided" )
-        
+
 
     # Unless we're pinging, make sure we have start and end times
     if options.ping:
@@ -204,13 +204,13 @@ def parse_command_line():
     else:
         if not options.gps_start_time:
             raise ValueError( "missing required argument --gps-start-time" )
-    
+
         if not options.gps_end_time:
             raise ValueError( "missing required argument --gps-end-time" )
 
         if not options.show_types and not options.include_segments:
             raise ValueError( "missing required argument --include-segments")
-    
+
     return options, database_location, file_location
 
 
@@ -260,7 +260,7 @@ class ShowTypesResultTable(table.Table):
         "segment_summary_end_time": "int_4s",
         "segment_summary_comment": "lstring"
         }
-    
+
 
 
 class ShowTypesResult(object):
@@ -286,7 +286,7 @@ ShowTypesResultTable.RowType = ShowTypesResult
 def run_show_types_dqsegdb(doc, protocol, server, gps_start_time, gps_end_time, included_segments_string, excluded_segments_string):
     resulttable = lsctables.New(ShowTypesResultTable)
     doc.childNodes[0].appendChild(resulttable)
-    
+
     #sql = """SELECT segment_definer.ifos, segment_definer.name, segment_definer.version,
     #             (CASE WHEN segment_definer.comment IS NULL THEN '-' WHEN segment_definer.comment IS NOT NULL THEN segment_definer.comment END),
     #             segment_summary.start_time, segment_summary.end_time,
@@ -327,13 +327,13 @@ def run_show_types_dqsegdb(doc, protocol, server, gps_start_time, gps_end_time, 
             result.ifos, result.name, result.version, result.segment_definer_comment, result.segment_summary_comment = key
             result.segment_summary_start_time, result.segment_summary_end_time = segment
             result.ifos = result.ifos.strip()
-        
+
             resulttable.append(result)
 
     #engine.close()
 
 
-    
+
 
 
 
@@ -379,7 +379,7 @@ def run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, g
             # Ok, we got a properly versioned query item, add it to the list:
             segments_to_query.append(spec)
         else:
-            versionQueryURL=urifunctions.constructVersionQueryURL(protocol,server,ifo,name) 
+            versionQueryURL=urifunctions.constructVersionQueryURL(protocol,server,ifo,name)
             if debug:
                 print versionQueryURL
             versionResult=urifunctions.getDataUrllib2(versionQueryURL)
@@ -407,7 +407,7 @@ def run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, g
             if key not in segment_types:
                 segment_types[key] = glue.segments.segmentlist([])
             segment_types[key] |= glue.segments.segmentlist([glue.segments.segment(segment_summary_start_time, segment_summary_end_time)])
-        
+
 
 #  old s6 query:
 #    for row in engine.query(sql):
@@ -436,7 +436,7 @@ def run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, g
 
         seg_def_id                     = seg_def_table.get_next_id()
         segment_definer                = lsctables.SegmentDef()
-        segment_definer.process_id     = process_id 
+        segment_definer.process_id     = process_id
         segment_definer.segment_def_id = seg_def_id
         segment_definer.ifos           = key[0]
         segment_definer.name           = key[1]
@@ -477,7 +477,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
     # the clientutils.calculate_combined_result function to generate the
     # final segments for the combined result
     # *_intermediate_JSON will contain the by-products of versionless queries
-    # where by-products mean the versioned results that are used to make the 
+    # where by-products mean the versioned results that are used to make the
     # combined versionless result
     included_JSON_results=[]
     included_intermediate_JSON=[]
@@ -499,7 +499,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
         # [('H1', 'DCH-TEST', 2, 1000000142, 1000000146, 0, 0), ('H1', 'DCH-TEST', 1 , 999999999, 1000000020, 0, 0), ('H1', 'DCH-TEST', 1, 1000000021, 1000000121, 0, 0), ('H1', 'DCH-TEST', 1, 1000000136, 1000000139, 0, 0), ('H1', 'DCH-TEST', 1, 1000000140, 1000000142, 0, 0)]
         # Of particular note: single version queries just use startTime and endTime, but versionless return the start and end time of the segment summaries that affect the final versionless result
         # This means that I need the versionless query above to return that additional information
-        
+
         if len(spec) is 3 and spec[2] is not '*':
             # This is a versioned query
             try:
@@ -543,7 +543,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
                     # Note that it appears I just need one segment summary that matches each segment definer above.
                     known_segments=glue.segments.segmentlist([glue.segments.segment(x[0],x[1]) for x in i_result['known']])
                     segment_summaries.append(known_segments&glue.segments.segmentlist([glue.segments.segment(seg[0],seg[1])]))
-    
+
     #n found_segments = segmentdb_utils.query_segments(engine, 'segment', segdefs)
     #n found_segments = reduce(operator.or_, found_segments).coalesce()
     #n ## Note: found_segments is a segments list of the RESULT after combining the segments, the xml result never includes the original segments for the flags queried, just the final result
@@ -553,7 +553,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
         print "Information on segdefs and segment_summaries: lengths, then first 10 entries"
         print len(segdefs)
         print len(segment_summaries)
-        if len(segdefs) > 10: 
+        if len(segdefs) > 10:
             print segdefs[:10]
         else:
             print segdefs
@@ -590,7 +590,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
             # [('H1', 'DCH-TEST', 2, 1000000142, 1000000146, 0, 0), ('H1', 'DCH-TEST', 1 , 999999999, 1000000020, 0, 0), ('H1', 'DCH-TEST', 1, 1000000021, 1000000121, 0, 0), ('H1', 'DCH-TEST', 1, 1000000136, 1000000139, 0, 0), ('H1', 'DCH-TEST', 1, 1000000140, 1000000142, 0, 0)]
             # Of particular note: single version queries just use startTime and endTime, but versionless return the start and end time of the segment summaries that affect the final versionless result
             # This means that I need the versionless query above to return that additional information
-            
+
             if len(spec) is 3 and spec[2] is not '*':
                 version = int(spec[2])
                 if version < 1:
@@ -645,7 +645,7 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
         print type(found_segments)
         print found_segments
 
-           
+
 
 
 #
@@ -659,13 +659,13 @@ def run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time
 # ER6 Kipp API CHANGES:
 class ContentHandler(ligolw.LIGOLWContentHandler):
     connection = None
-# 
+#
 # def setup_files(dir_name, gps_start_time, gps_end_time):
 #     # Filter out the ones that are outside our time range
 #@@ -477,7 +478,13 @@ def setup_files(dir_name, gps_start_time, gps_end_time):
 #     target     = dbtables.get_connection_filename(temp_db, None, True, False)
 #     connection = ligolw_sqlite.setup(target)
-# 
+#
 #-    ligolw_sqlite.insert_from_urls(connection, xml_files) # [temp_xml])
 #+    ContentHandler.connection = connection
 #+    dbtables.use_in(ContentHandler)
@@ -691,9 +691,9 @@ def setup_files(dir_name, gps_start_time, gps_end_time):
     ligolw_sqlite.insert_from_urls(xml_files, ContentHandler)
 
     segmentdb_utils.ensure_segment_table(connection)
-        
+
     return temp_db, connection
-    
+
 #
 # =============================================================================
 #
@@ -703,7 +703,7 @@ def setup_files(dir_name, gps_start_time, gps_end_time):
 #
 
 if __name__ == '__main__':
-    options, database_location, file_location  = parse_command_line()    
+    options, database_location, file_location  = parse_command_line()
 
     # Ping the database and exit if requested
     if options.ping:
@@ -723,7 +723,7 @@ if __name__ == '__main__':
             server_version=flags_information['query_information']['api_version']
             print "Server version is %s" % server_version
             sys.exit(0)
-            
+
 
 
     #gps_start_time = int(options.gps_start_time)
@@ -739,7 +739,7 @@ if __name__ == '__main__':
     temp_files = False
 
     if database_location and not options.use_s6:
-        # Use new dqsegdb client 
+        # Use new dqsegdb client
         o=urlparse.urlparse(options.segment_url)
         protocol=o.scheme
         server=o.netloc
@@ -748,11 +748,11 @@ if __name__ == '__main__':
 
         if options.query_segments:
             run_query_segments_dqsegdb(doc, process_id, protocol, server, gps_start_time, gps_end_time, options.include_segments, options.exclude_segments, options.result_name)
-        
+
         if options.query_types:
             warnings.warn("Notice: This call has not been optimized for DQSEGDB yet, and may take a few minutes.")
             run_query_types_dqsegdb(doc, process_id, protocol, server, gps_start_time, gps_end_time, options.include_segments)
-    
+
     else:
         # Run old client
         warnings.warn('Warning: using old client code that may be less carefully maintained than DQSEGDB clients.')
@@ -760,15 +760,15 @@ if __name__ == '__main__':
             connection = segmentdb_utils.setup_database(database_location)
             engine     = query_engine.LdbdQueryEngine(connection)
         else:
-            temp_db, connection = setup_files(file_location, gps_start_time, gps_end_time) 
+            temp_db, connection = setup_files(file_location, gps_start_time, gps_end_time)
             engine     = query_engine.SqliteQueryEngine(connection)
             temp_files = True
         if options.show_types:
             clientutils.run_show_types(doc, connection, engine, gps_start_time, gps_end_time, options.include_segments,options.exclude_segments)
-    
+
         if options.query_segments:
             clientutils.run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, options.include_segments, options.exclude_segments, options.result_name)
-    
+
         if options.query_types:
             clientutils.run_query_types(doc, process_id, connection, engine, gps_start_time, gps_end_time, options.include_segments)
 

--- a/bin/ligolw_segment_query_dqsegdb
+++ b/bin/ligolw_segment_query_dqsegdb
@@ -1,17 +1,17 @@
 #!/usr/bin/python
 #
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #

--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -1,35 +1,6 @@
 #!/usr/bin/env python
-## Copyright (C) 2015 Ryan Fisher, Gary Hemming
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (C) 2009 Larne Pekowsky
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
-# Copyright (C) 2009  Larne Pekowsky
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -28,7 +28,7 @@
 
 """
 Takes one or more segment XML files and a query file, runs the query against
-the segments, and produces veto files as XML.  Produces output to match S6 
+the segments, and produces veto files as XML.  Produces output to match S6
 style segment database tools.
 """
 
@@ -65,8 +65,8 @@ from glue.ligolw.utils import process
 
 from glue import git_version
 
-from dqsegdb import apicalls 
-from dqsegdb import clientutils 
+from dqsegdb import apicalls
+from dqsegdb import clientutils
 
 import re
 import urllib
@@ -101,9 +101,9 @@ def parse_command_line():
     parser = OptionParser(
         version = "Name: %%prog\n%s" % git_version.verbose_msg,
         usage   = "%prog -v|--veto-file filename [options]",
-        description = "Reads one or more segment files and a veto file and generates files of veto segments"        
+        description = "Reads one or more segment files and a veto file and generates files of veto segments"
 	)
-    
+
     parser.add_option("-v", "--veto-file",    metavar = "veto_file",    help = "veto XML file (required).")
     parser.add_option("-o", "--output-dir",   metavar = "output_dir",   default = '.',          help = "Directory to write output (default=cwd).")
     parser.add_option("-k", "--keep-db",      metavar = "keep_db",      action  = "store_true", help = "Keep sqlite database.")
@@ -128,7 +128,7 @@ def parse_command_line():
 
     if not options.veto_file:
         raise ValueError, "missing required argument --veto-file"
-   
+
     # User must specify how to treat the categories
     if not (options.cumulative_categories or options.separate_categories) or (options.cumulative_categories and options.separate_categories):
         print >>sys.stderr, "Must provide one of --cumulative-categories | --separate-categories"
@@ -150,7 +150,7 @@ def parse_command_line():
 
         # Grab the part of the name after the last slash
         pos     = options.veto_file[::-1].find('/')
-        fname   = (pos > -1) and options.veto_file[ -1 * pos:] or "veto_definer.xml" 
+        fname   = (pos > -1) and options.veto_file[ -1 * pos:] or "veto_definer.xml"
 
         loaded_file = tmp_dir + "/" + fname
 
@@ -175,10 +175,10 @@ def parse_command_line():
             file_location = options.segment_url[len('file://'):]
         else:
             tmp_dir = tempfile.mkdtemp()
-        
+
             # Grab the part of the name after the last slash
             pos     = options.segment_url[::-1].find('/')
-            fname   = (pos > -1) and options.segment_url[ -1 * pos:] or "dmt.xml" 
+            fname   = (pos > -1) and options.segment_url[ -1 * pos:] or "dmt.xml"
 
             inurl   = urllib.urlopen(options.segment_url)
             outfile = open(tmp_dir + "/" + fname, 'w')
@@ -207,11 +207,11 @@ def parse_command_line():
 
     if not options.gps_start_time:
         raise ValueError( "missing required argument --gps-start-time" )
-    
+
     if not options.gps_end_time:
         raise ValueError( "missing required argument --gps-end-time" )
 
-        
+
     return options, database_location, file_location, loaded_file, debug
 
 
@@ -266,7 +266,7 @@ if __name__ == '__main__':
 
     dbtables.get_column_info = kludge_get_column_info
 
-    options, db_location, file_location, loaded_file, debug = parse_command_line()    
+    options, db_location, file_location, loaded_file, debug = parse_command_line()
 
     if options.non_integer:
         allow_non_int=True
@@ -274,7 +274,7 @@ if __name__ == '__main__':
         allow_non_int=False
     now = gpstime.GpsSecondsFromPyUTC(time.time())
 
-    # 1. Load the veto file into sqlite    
+    # 1. Load the veto file into sqlite
     handle, temp_db    = tempfile.mkstemp(suffix='.sqlite')
     os.close(handle)
     target          = dbtables.get_connection_filename(temp_db, None, True, False)
@@ -291,7 +291,7 @@ if __name__ == '__main__':
         min_start_time = int(options.gps_start_time)
         max_end_time   = int(options.gps_end_time)
     # 2. If we're working with DMT files load them into sqlite as well
-    
+
     if file_location:
         xml_files += segmentdb_utils.get_all_files_in_range(file_location, min_start_time, max_end_time)
         segment_query_engine = veto_query_engine
@@ -309,12 +309,12 @@ if __name__ == '__main__':
     # If we're working with DMT files make sure we have a segment table
     if file_location:
         segmentdb_utils.ensure_segment_table(veto_connection)
-    
+
     #cli_interval = glue.segments.segmentlist([glue.segments.segment(int(options.gps_start_time), int(options.gps_end_time))])
     cli_interval = glue.segments.segmentlist([glue.segments.segment(min_start_time,max_end_time)])
-            
+
     #
-    # Get the set of veto categories and ifos for which we have segments 
+    # Get the set of veto categories and ifos for which we have segments
     #
     #categories = [row[0] for row in veto_query_engine.query("select distinct(category) from veto_definer")]
     #ifos       = [row[0] for row in veto_query_engine.query("select distinct(ifo) from veto_definer")]
@@ -429,7 +429,7 @@ if __name__ == '__main__':
             manual_debug=False
             #manual_debug=True
             if manual_debug:
-                import pdb 
+                import pdb
                 pdb.set_trace()
             # Form the result
             if len(vetoed_segments)>0:
@@ -440,17 +440,17 @@ if __name__ == '__main__':
             seg_def_id = segmentdb_utils.add_to_segment_definer(doc, proc_id, ifo, seg_name, 1)
 
             # and segment summary
-            if allow_non_int: 
+            if allow_non_int:
                 clientutils.add_to_segment_summary_ns(doc, proc_id, seg_def_id, [[min_start_time, max_end_time]])
             else:
                 segmentdb_utils.add_to_segment_summary(doc, proc_id, seg_def_id, [[min_start_time, max_end_time]])
 
             # and store the segments
-            if allow_non_int: 
+            if allow_non_int:
                 clientutils.add_to_segment_ns(doc, proc_id, seg_def_id, vetoed_segments)
             else:
                 segmentdb_utils.add_to_segment(doc, proc_id, seg_def_id, vetoed_segments)
-            
+
             # Dump to XML
             output_name = "%s/%s-VETOTIME_CAT%d-%d-%d.xml" % (options.output_dir, ifo, category_num, min_start_time, (max_end_time - min_start_time))
             utils.write_filename(doc, output_name)

--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -1,30 +1,30 @@
 #!/usr/bin/env python
 ## Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #

--- a/dqsegdb/__init__.py
+++ b/dqsegdb/__init__.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from . import *

--- a/dqsegdb/apicalls.py
+++ b/dqsegdb/apicalls.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys

--- a/dqsegdb/apicalls.py
+++ b/dqsegdb/apicalls.py
@@ -53,10 +53,10 @@ author = "Ryan Fisher"
 verbose=False
 
 def dqsegdbCheckVersion(protocol,server,ifo,name,version):
-    """ 
+    """
     Checks for existence of a given version of a flag in the db.
     Returns true if version exists
-    
+
     Parameters
     ----------
     protocol : `string`
@@ -82,7 +82,7 @@ def dqsegdbCheckVersion(protocol,server,ifo,name,version):
     ult_json=json.loads(result)
     version_list=result_json['version']
     if version in version_list:
-        return True 
+        return True
     else:
         return False
 
@@ -92,10 +92,10 @@ def dqsegdbCheckVersion(protocol,server,ifo,name,version):
     # Con?
 
 def dqsegdbMaxVersion(protocol,server,ifo,name):
-    """ 
+    """
     Checks for existence of a flag in the db, returns maximum
     version if the flag exists exists, 0 if the flag does not exist.
-    
+
     Parameters
     ----------
     protocol : `string`
@@ -120,7 +120,7 @@ def dqsegdbMaxVersion(protocol,server,ifo,name):
             raise
     # Now parse result for max version:
     queryurl=urifunctions.constructVersionQueryURL(protocol,server,ifo,name)
-    try: 
+    try:
         result=urifunctions.getDataUrllib2(queryurl,warnings=False)
     except HTTPError as e:
         if int(e.code)==404:
@@ -153,7 +153,7 @@ def dqsegdbFindEndTime(flag_dict):
         return None
 
 def dqsegdbQueryTimes(protocol,server,ifo,name,version,include_list_string,startTime,endTime):
-    """ 
+    """
     Issue query to server for ifo:name:version with start and end time
     Returns the python loaded JSON response!
 
@@ -183,7 +183,7 @@ def dqsegdbQueryTimes(protocol,server,ifo,name,version,include_list_string,start
 
 #dqsegdbQueryTimesCompatible
 def dqsegdbQueryTimesCompatible(protocol,server,ifo,name,version,include_list_string,startTime,endTime):
-    """ 
+    """
     Issue query to server for ifo:name:version with start and end time
     This is the version that reproduces S6 style query results when the query is empty
     Returns the python loaded JSON response!
@@ -216,14 +216,14 @@ def dqsegdbQueryTimesCompatible(protocol,server,ifo,name,version,include_list_st
         if e.code==404:
             # For S6 executable compatibility, we need to return something anyway to make ligolw_segments_from_cats and segment_query work properly, in this case, we'll return a faked up dictionary with empty lists for keys 'known' and 'active', which the calling functions will correctly interperet (because it's the equivalent of asking for a flag outside known time for the S6 calls)
             result_json={"known":[],"active":[]}
-        else: 
+        else:
             raise
 
     return result_json,queryurl
 
 
 def dqsegdbQueryTimeless(protocol,server,ifo,name,version,include_list_string):
-    """ 
+    """
     Issue query to server for ifo:name:version without start and end time
     Returns the python loaded JSON response converted into a dictionary and queryurl!
     Returns
@@ -260,7 +260,7 @@ def coalesceResultDictionary(result_dict):
         This is the input result dictionary from the other api calls
     out_result_dict : `dict`
         This is the output result dictionary with actual segment lists (and coalesced results).
-        
+
     """
     import copy
     out_result_dict=copy.deepcopy(result_dict)
@@ -278,7 +278,7 @@ def queryAPIVersion(protocol,server,verbose):
     """
     Construct url and issue query to get the reported list of all IFOs
     provided by dqsegd and the API version of the server.
-    
+
     Parameters
     ----------
     protocol : `string`
@@ -301,7 +301,7 @@ def reportFlags(protocol,server,verbose):
     provided by dqsegdb.
     From the API Doc:
     Get a JSON formatted string resource describing all the flags in the database. This provides an optimization by returning all flag names and all associated versions in a single call.
-    
+
     Parameters
     ----------
     protocol : `string`
@@ -384,77 +384,77 @@ def reportKnown(protocol,server,includeSegments,verbose,gps_start_time,gps_end_t
 
 def parseKnown(jsonResult):
     """
-    Accepts jsonResult from reportKnown call and parses into expected format 
+    Accepts jsonResult from reportKnown call and parses into expected format
     for ligolw_segment_query client to generate xml.
     """
     rows=[]
     resultDictionary=json.loads(jsonResult)
     #ifos, name, version, segment_definer_comment, segment_summary_start_time, segment_summary_end_time, segment_summary_comment = row
-    # json looks like this: 
+    # json looks like this:
     #{
     #    "query_information": {
-    #        "api_version": 1, 
-    #        "end": "1076401264", 
-    #        "include": [], 
-    #        "server": "dqsegdb5.phy.syr.edu", 
+    #        "api_version": 1,
+    #        "end": "1076401264",
+    #        "include": [],
+    #        "server": "dqsegdb5.phy.syr.edu",
     #        # Jul 28: api_version replaced server_code_version
-    #        "server_code_version": "v1r5", 
-    #        "server_elapsed_query_time": 2.3630100000000001, 
-    #        "server_timestamp": 1079895401, 
-    #        "start": "1076400544", 
+    #        "server_code_version": "v1r5",
+    #        "server_elapsed_query_time": 2.3630100000000001,
+    #        "server_timestamp": 1079895401,
+    #        "start": "1076400544",
     #        "uri": "/report/known?s=1076400544&e=1076401264"
-    #    }, 
+    #    },
     #    "results": [
     #        {
-    #            "ifo": "L1", 
+    #            "ifo": "L1",
     #            "known": [
     #                [
-    #                    1076400480, 
+    #                    1076400480,
     #                    1076400848
-    #                ], 
+    #                ],
     #                [
-    #                    1076400848, 
+    #                    1076400848,
     #                    1076401200
-    #                ], 
+    #                ],
     #                [
-    #                    1076401200, 
+    #                    1076401200,
     #                    1076401568
     #                ]
-    #            ], 
+    #            ],
     #            "metadata": {
-    #                "active_indicates_ifo_badness": false, 
-    #                "comment": "L1 interferometer Up from h(t) DQ flags", 
-    #                "deactivated": false, 
+    #                "active_indicates_ifo_badness": false,
+    #                "comment": "L1 interferometer Up from h(t) DQ flags",
+    #                "deactivated": false,
     #                "provenance_url": "This is where the url should go"
-    #            }, 
-    #            "name": "DMT-UP", 
+    #            },
+    #            "name": "DMT-UP",
     #            "version": 1
-    #        }, 
+    #        },
     #        {
-    #            "ifo": "L1", 
+    #            "ifo": "L1",
     #            "known": [
     #                [
-    #                    1076400848, 
+    #                    1076400848,
     #                    1076401200
-    #                ], 
+    #                ],
     #                [
-    #                    1076401200, 
+    #                    1076401200,
     #                    1076401568
-    #                ], 
+    #                ],
     #                [
-    #                    1076400480, 
+    #                    1076400480,
     #                    1076400848
     #                ]
-    #            ], 
+    #            ],
     #            "metadata": {
-    #                "active_indicates_ifo_badness": false, 
-    #                "comment": "L1 interferometer Up from h(t) DQ flags", 
-    #                "deactivated": false, 
+    #                "active_indicates_ifo_badness": false,
+    #                "comment": "L1 interferometer Up from h(t) DQ flags",
+    #                "deactivated": false,
     #                "provenance_url": "This is where the url should go"
-    #            }, 
-    #            "name": "DMT-SCIENCE", 
+    #            },
+    #            "name": "DMT-SCIENCE",
     #            "version": 1
-    #        }, 
+    #        },
     for i in resultDictionary['results']:
         # Ex: >>> resultDict['results'][0]
         #{u'known': [[1076400480, 1076400848], [1076400848, 1076401200], [1076401200, 1076401568]], u'ifo': u'L1', u'name': u'DMT-UP', u'version': 1, u'metadata': {u'comment': u'L1 interferometer Up from h(t) DQ flags', u'provenance_url': u'This is where the url should go', u'active_indicates_ifo_badness': False, u'deactivated': False}}
@@ -474,9 +474,9 @@ def parseKnown(jsonResult):
     return rows
 
 def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, startTime, endTime, debug=False):
-    """ 
+    """
     Queries server for needed flag_versions to generate the result of a
-    cascaded query (was called a versionless query in S6).  
+    cascaded query (was called a versionless query in S6).
 
     Returns a python dictionary representing the calculated result "versionless"
     flag and also the python dictionaries (in a list) for the flag_versions
@@ -508,7 +508,7 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
     else:
         verbose=False
 
-    ## Construct url and issue query to determine highest version from list 
+    ## Construct url and issue query to determine highest version from list
     ## of versions
     versionQueryURL=urifunctions.constructVersionQueryURL(protocol,server,ifo,name)
     if verbose:
@@ -544,7 +544,7 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
         # sort list by decreasing version number and call each URL:
         sortedurlList=sorted(urlList, key=lambda url: url.split('/')[-1], reverse=True)
         for versioned_url in sortedurlList:
-            # I am assuming I need to pull off the versions from the urls to use my existing library function.  
+            # I am assuming I need to pull off the versions from the urls to use my existing library function.
             # Alternatively, we could make a new library function that starts from the end of the version and takes the include_list_string and start and end times as inputs
             version=versioned_url.split('/')[-1]
             queryurl=urifunctions.constructSegmentQueryURLTimeWindow(protocol,server,ifo,name,version,include_list_string,startTime,endTime)
@@ -553,7 +553,7 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
             result=urifunctions.getDataUrllib2(queryurl)
             result_parsed=json.loads(result)
             jsonResults.append(result_parsed)
-            # Fix!!! Improvement: Executive Decision:  Should we force these intermediate results to hit disk?  
+            # Fix!!! Improvement: Executive Decision:  Should we force these intermediate results to hit disk?
             # For now, I say yes:
             # Fix!!! Improvement: Choose a better location for files to go automatically, so this can be run from other directories
             filename=queryurl.replace('/','_').split(':')[-1]+'.json'
@@ -567,12 +567,12 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
                     print "Couldn't save partial results to disk.... continuing anyway."
 
     ## Construct output segments lists from multiple JSON objects
-    # The jsonResults are in order of decreasing versions, 
+    # The jsonResults are in order of decreasing versions,
     # thanks to the sorting above
-    # This generates a results_flag object for dumping to JSON with the 
+    # This generates a results_flag object for dumping to JSON with the
     # total_known_list across all versions, cascaded
     # and we have the total active list across all versions, cascaded
-    # so we're done the math! : 
+    # so we're done the math! :
     result_flag,affected_results=clientutils.calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=ifo)
     if verbose:
         print "active segments:", result_flag['active']
@@ -599,9 +599,9 @@ def dqsegdbCascadedQuery(protocol, server, ifo, name, include_list_string, start
     #    json_result['flags'].append(flag)
     #json_result['flags'].append(result_flag)
 
-    # Now we need to return the reduced results and the intermediate JSON 
+    # Now we need to return the reduced results and the intermediate JSON
     # responses from the versioned queries
-    # Note: The result_flag will not have query_metadata 
+    # Note: The result_flag will not have query_metadata
     return result_flag,jsonResults,affected_results
 
 def dtd_uri_callback(uri):
@@ -617,7 +617,7 @@ def dtd_uri_callback(uri):
     else:
         # otherwise just use the uri in the file
         return uri
-    
+
 
 
 def waitTill(runTime,timeout=2400):
@@ -657,7 +657,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
     except HTTPError as e:
         if e.code!=404:
             raise e
-        try: 
+        try:
             #put to version
             if debug:
                 inlogger.debug("Trying to put alone for url: %s" % url)
@@ -683,7 +683,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
 
 
 def threadedPatchWithFailCases(q,server,debug,inputlogger=None):
-    """ 
+    """
     Used by InsertMultipleDQXMLFileThreaded
     to patch data to server. (Deprecated/Incomplete error handling)
     """
@@ -715,14 +715,14 @@ def setupSegment_md(filename,xmlparser,lwtparser,debug):
     return segment_md
 
 def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.virgo.infn.it',hackDec11=False,debug=True,threads=1,testing_options={}):
-    """ 
+    """
     Inserts multiple dqxml files of data into the DQSEGDB.
 
     Input:
     - filenames is a list of string filenames for  DQXML files.
-    - hackDec11 is deprecated (always should be false): This was used to differentiate function against different server APIs before we used numbering an responses to make decisions. 
+    - hackDec11 is deprecated (always should be false): This was used to differentiate function against different server APIs before we used numbering an responses to make decisions.
     - testing_options is a dictionary including (optionally):offset(int),synchronize(time in 'HH:MM' format (string))
-    
+
     Output:
     returns True if it completes sucessfully
     """
@@ -740,7 +740,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         # S6 style comments are needed
         new_comments=True
     else:
-        # Older server, so don't want to supply extra comments... 
+        # Older server, so don't want to supply extra comments...
         new_comments=False
     if apiResult >= "2.1.15":
         # Alteration to insertion_metadata from uri to comment to accomodate s6 data conversion
@@ -758,9 +758,9 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
 
     xmlparser = pyRXP.Parser()
     lwtparser = ldbd.LIGOLwParser()
-    
+
     flag_versions = {}
-    
+
     # flag_versions, filename, server, hackDec11, debug are current variables
 
     # This next bunch of code is specific to a given file:
@@ -768,31 +768,31 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         print "Empty file list sent to InsertMultipleDQXMLFileThreaded"
         raise ValueError
     for filename in filenames:
-    
+
         segment_md = setupSegment_md(filename,xmlparser,lwtparser,debug)
 
         # segment_md, flag_versions, filename, server, hackDec11, debug are current variables
-        
+
         flag_versions_numbered = {}
-        
+
         for j in range(len(segment_md.table['segment_definer']['stream'])):
             flag_versions_numbered[j] = {}
             for i,entry in enumerate(segment_md.table['segment_definer']['orderedcol']):
               #print j,entry,segment_md.table['segment_definer']['stream'][j][i]
               flag_versions_numbered[j][entry] = segment_md.table['segment_definer']['stream'][j][i]
-        
-        
+
+
         # parse process table and make a dict that corresponds with each
         # process, where the keys for the dict are like "process:process_id:1"
         # so that we can match
         # these to the flag_versions from the segment definer in the next
         # section
-        
+
         # Note:  Wherever temp_ preceeds a name, it is generally an identifier
         # field from the dqxml, that is only good for the single dqxml file
         # being parsed
-        
-        
+
+
         process_dict = {}
         # Going to assign process table streams to process_dict with a key
         # matching process_id (process:process_id:0 for example)
@@ -833,15 +833,15 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             process_dict[temp_process_id]['process_metadata']['pid'] = process_dict[temp_process_id]['unix_procid']
             process_dict[temp_process_id]['process_metadata']['name'] = process_dict[temp_process_id]['program']
             process_dict[temp_process_id]['process_metadata']['fqdn'] = process_dict[temp_process_id]['node'] ### Fix!!! Improvement: not really fqdn, just the node name
-        
+
         # So now I have process_dict[temp_process_id]['process_metadata'] for each
         # process_id, and can add it to a flag version when it uses it;  really I
         # should group it with the segment summary info because that has the
         # insertion_metadata start and stop time
-        
+
         ### Fix!!! Get the args from the *other* process table... yikes
         ### Double check what is done below works!
-        # First pass: 
+        # First pass:
         #if debug:
         #    import pdb
         #    pdb.set_trace()
@@ -868,9 +868,9 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
         #if debug:
         #    import pdb
         #    pdb.set_trace()
-        
+
         temp_id_to_flag_version = {}
-        
+
         for i in flag_versions_numbered.keys():
             ifo = flag_versions_numbered[i]['ifos']
             name = flag_versions_numbered[i]['name']
@@ -890,13 +890,13 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             flag_versions[(ifo,name,version)].temporary_process_id = flag_versions_numbered[i]['process_id']
             # Populate reverse lookup dictionary:
             temp_id_to_flag_version[flag_versions[(ifo,name,version)].temporary_definer_id] = (ifo,name,version)
-        
-        
+
+
         # ways to solve the metadata problem:
         # Associate each insertion_metadata block with a process, then group
         # them and take the min insert_data_start and max insert_data_stop
-        
-        
+
+
         # parse segment_summary table and associate known segments with
         # flag_versions above:
         ## Note this next line is needed for looping over multiple files
@@ -919,7 +919,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
             new_seg_summary = segments.segmentlist([segments.segment(start_time,end_time)])
             flag_versions[(ifo,name,version)].appendKnown(new_seg_summary)
             # Now I need to build up the insertion_metadata dictionary for this
-            # summary: 
+            # summary:
             # Now I need to associate the right process with the known
             # segments here, and put the start and end time into the
             # insertion_metadata part of the
@@ -951,8 +951,8 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
                 flag_versions[(ifo,name,version)].temp_process_ids[temp_process_id] = {}
                 flag_versions[(ifo,name,version)].temp_process_ids[temp_process_id]['insert_data_start'] = start_time
                 flag_versions[(ifo,name,version)].temp_process_ids[temp_process_id]['insert_data_stop'] = end_time
-        
-        
+
+
         # Now, I need to append an insert_history element to the flag_versions
         # for this ifo,name, version, as I have the correct insertion_metadata
         # and the correct
@@ -964,7 +964,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
                 start = flag_versions[i].temp_process_ids[pid]['insert_data_start']
                 stop = flag_versions[i].temp_process_ids[pid]['insert_data_stop']
                 if new_comments:
-                    flag_versions[i].flag_version_comment=process_dict[pid]['process_comment']  
+                    flag_versions[i].flag_version_comment=process_dict[pid]['process_comment']
                 insert_history_dict = {}
                 try:
                     insert_history_dict['process_metadata'] = process_dict[pid]['process_metadata']
@@ -1020,7 +1020,7 @@ def InsertMultipleDQXMLFileThreaded(filenames,logger,server='http://slwebtest.vi
 
     for i in flag_versions.keys():
         flag_versions[i].coalesceInsertHistory()
-    
+
     if threads>1:
         # Call this after the loop over files, and we should be good to go
         concurrent=min(threads,len(i)) # Fix!!! why did I do len(i) ???

--- a/dqsegdb/clientutils.py
+++ b/dqsegdb/clientutils.py
@@ -36,7 +36,7 @@ from dqsegdb import jsonhelper
 def include_exclude_caller(includedList,excludedList,startTime,endTime,protocol, server,include_list_string):
     """
     Function to query the dqsegdb for lists of included and excluded flags.
-    Returns lists of JSON for the included and excluded flags and lists of 
+    Returns lists of JSON for the included and excluded flags and lists of
     URLs used to query the database.
 
     Parameters
@@ -83,7 +83,7 @@ def include_exclude_caller(includedList,excludedList,startTime,endTime,protocol,
     return includedJSON,includedURL,excludedJSON,excludedURL,ifo
 
 def calculate_combined_result(includedJSON,excludedJSON,startTime,endTime,ifo):
-    """ 
+    """
     Calculate the result of the union of the active times for the included flag less the intersection of that result with the union of the excluded flags
     Inputs are 2 lists of python dictionaries representing the JSON (already have run json.loads() on the JSON), a start time, and end time, and the ifo name (it does not make sense to include/exclude across multiple ifos)
 
@@ -97,58 +97,58 @@ def calculate_combined_result(includedJSON,excludedJSON,startTime,endTime,ifo):
         Ex: 'L1'
 
     """
-    total_active_list=segments.segmentlist([]) 
-    for flag in includedJSON: 
-        #result=json.loads(flag) 
-        #flagDict=result['flags'][0] 
-        active_list=flag['active'] 
-        active_segments=segments.segmentlist([segments.segment(x[0],x[1]) for x in active_list]) 
-        total_active_list=total_active_list+active_segments 
+    total_active_list=segments.segmentlist([])
+    for flag in includedJSON:
+        #result=json.loads(flag)
+        #flagDict=result['flags'][0]
+        active_list=flag['active']
+        active_segments=segments.segmentlist([segments.segment(x[0],x[1]) for x in active_list])
+        total_active_list=total_active_list+active_segments
         total_active_list.coalesce()
-    for flag in excludedJSON: 
-        #result=json.loads(flag) 
-        #flagDict=result['flags'][0] 
-        active_list=flag['active'] 
-        active_segments=segments.segmentlist([segments.segment(x[0],x[1]) for x in active_list]) 
-        total_active_list=total_active_list-active_segments 
+    for flag in excludedJSON:
+        #result=json.loads(flag)
+        #flagDict=result['flags'][0]
+        active_list=flag['active']
+        active_segments=segments.segmentlist([segments.segment(x[0],x[1]) for x in active_list])
+        total_active_list=total_active_list-active_segments
         total_active_list.coalesce()
-    # Now, total_active_list contains a segmentlist object with segments spanning the expected result     # includedJSON and excludedJSON contain lists of JSON text blobs (not parsed with json.loads yet) 
- 
-    ## Note:  About known segments for the result:  We just report the start and end time of the period queried!  If you wanted to report the actual validity of multiple segments, it's somewhat undefined if the excluded ones and/or some of the included flags aren't known about for a time when the included ones are;  Technically since exclusion trumps all inclusions, if an excluded segment is known and active at any given time, the result is known for that time explicitly. 
-    result_known_segment_list=segments.segmentlist([segments.segment(startTime,endTime)]) 
- 
-    ## Now we have to build the JSON for this flag 
-    # JSON flag objects looks like this (each is a dictionary!): 
-    #  { 
-    #    "ifo" : "ifo", 
-    #    "name" : "flag", 
-    #    "version" : n, 
-    #    "comment" : "description",     #    "provenance_url" : "aLog URL", 
-    #    "deactivated" : false|true, 
-    #    "active_indicates_ifo_badness" : true|false|null, 
-    #    // known segments returned for both /active and /known URIs, no segments are returned for the /metadata or /report/flags queries 
-    #    // aka S6 summary segments 
-    #    "known" : [ [ts,te], [ts,te], ... ] 
-    #    // active segments returned only for /active URI: 
-    #    "active" : [ [ts,te], [ts,te], ... ] 
-    #    // \textcolor{red}{Comment: or "segment" : [ [ts,te,value], [ts,te,value], ...] (where value can be -1,0 or +1)} 
-    #    // inactive == (known - active) 
-    #    // unknown == (all_time - known) 
-    #  }, 
-    ## Make the json-ready flag dictionary for the combined result: 
-    ifo=ifo # replicating old behavoir from ligolw_segment_query 
-    # Note: This just uses the ifo of the last excluded flag! 
-    name='RESULT' 
-    version=1 
-    known_segments=result_known_segment_list 
-    active_segments=total_active_list 
+    # Now, total_active_list contains a segmentlist object with segments spanning the expected result     # includedJSON and excludedJSON contain lists of JSON text blobs (not parsed with json.loads yet)
+
+    ## Note:  About known segments for the result:  We just report the start and end time of the period queried!  If you wanted to report the actual validity of multiple segments, it's somewhat undefined if the excluded ones and/or some of the included flags aren't known about for a time when the included ones are;  Technically since exclusion trumps all inclusions, if an excluded segment is known and active at any given time, the result is known for that time explicitly.
+    result_known_segment_list=segments.segmentlist([segments.segment(startTime,endTime)])
+
+    ## Now we have to build the JSON for this flag
+    # JSON flag objects looks like this (each is a dictionary!):
+    #  {
+    #    "ifo" : "ifo",
+    #    "name" : "flag",
+    #    "version" : n,
+    #    "comment" : "description",     #    "provenance_url" : "aLog URL",
+    #    "deactivated" : false|true,
+    #    "active_indicates_ifo_badness" : true|false|null,
+    #    // known segments returned for both /active and /known URIs, no segments are returned for the /metadata or /report/flags queries
+    #    // aka S6 summary segments
+    #    "known" : [ [ts,te], [ts,te], ... ]
+    #    // active segments returned only for /active URI:
+    #    "active" : [ [ts,te], [ts,te], ... ]
+    #    // \textcolor{red}{Comment: or "segment" : [ [ts,te,value], [ts,te,value], ...] (where value can be -1,0 or +1)}
+    #    // inactive == (known - active)
+    #    // unknown == (all_time - known)
+    #  },
+    ## Make the json-ready flag dictionary for the combined result:
+    ifo=ifo # replicating old behavoir from ligolw_segment_query
+    # Note: This just uses the ifo of the last excluded flag!
+    name='RESULT'
+    version=1
+    known_segments=result_known_segment_list
+    active_segments=total_active_list
     result_flag=jsonhelper.buildFlagDict(ifo,name,version,known_segments,active_segments)
     return result_flag
 
 def calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=None):
     """
     Construct output segments lists from multiple JSON objects.
-    The jsonResults input is a list of json ojbects and 
+    The jsonResults input is a list of json ojbects and
     are expected to be in order of decreasing versions.
     """
     debug=False
@@ -213,7 +213,7 @@ def calculate_versionless_result(jsonResults,startTime,endTime,ifo_input=None):
 ################################
 #
 #  S6 Client Utilities
-# 
+#
 ################################
 
 def seg_spec_to_sql(spec):
@@ -251,7 +251,7 @@ class ShowTypesResultTable(table.Table):
         "segment_summary_end_time": "int_4s",
         "segment_summary_comment": "lstring"
         }
-    
+
 
 
 class ShowTypesResult(object):
@@ -277,7 +277,7 @@ ShowTypesResultTable.RowType = ShowTypesResult
 def run_show_types(doc, connection, engine, gps_start_time, gps_end_time, included_segments_string, excluded_segments_string):
     resulttable = lsctables.New(ShowTypesResultTable)
     doc.childNodes[0].appendChild(resulttable)
-    
+
     sql = """SELECT segment_definer.ifos, segment_definer.name, segment_definer.version,
                  (CASE WHEN segment_definer.comment IS NULL THEN '-' WHEN segment_definer.comment IS NOT NULL THEN segment_definer.comment END),
                  segment_summary.start_time, segment_summary.end_time,
@@ -308,7 +308,7 @@ def run_show_types(doc, connection, engine, gps_start_time, gps_end_time, includ
             result.ifos, result.name, result.version, result.segment_definer_comment, result.segment_summary_comment = key
             result.segment_summary_start_time, result.segment_summary_end_time = segment
             result.ifos = result.ifos.strip()
-        
+
             resulttable.append(result)
 
     engine.close()
@@ -451,7 +451,7 @@ def run_query_segments(doc, process_id, engine, gps_start_time, gps_end_time, in
     segmentdb_utils.add_to_segment(doc, process_id, seg_def_id, found_segments)
     print "Made it to the end of the query code"
     print doc
-           
+
 
 
 #
@@ -476,9 +476,9 @@ def setup_files(dir_name, gps_start_time, gps_end_time):
     ligolw_sqlite.insert_from_urls(connection, xml_files) # [temp_xml])
 
     segmentdb_utils.ensure_segment_table(connection)
-        
+
     return temp_db, connection
-   
+
 def add_to_segment_ns(xmldoc, proc_id, seg_def_id, sgmtlist):
     try:
         segtable = table.get_table(xmldoc, lsctables.SegmentTable.tableName)

--- a/dqsegdb/clientutils.py
+++ b/dqsegdb/clientutils.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys

--- a/dqsegdb/jsonhelper.py
+++ b/dqsegdb/jsonhelper.py
@@ -25,7 +25,7 @@ import glue.segments as segments
 #  is trivial, as shown here:
 #
 # Example from a file:
-#[rpfisher@sugar-dev2 ~]$ cat test_jsonnocomments.json 
+#[rpfisher@sugar-dev2 ~]$ cat test_jsonnocomments.json
 #{
 # "meta": {
 #    "query_uri" : "uri",
@@ -42,9 +42,9 @@ import glue.segments as segments
 ################################################################################
 
 def convertJSONtoXML(json_response):
-    """ 
+    """
     Incomplete!!
-    Converts a standard JSON response from the dqsegdb server into a 
+    Converts a standard JSON response from the dqsegdb server into a
     DQXML format.
 
     """
@@ -80,9 +80,9 @@ def convertJSONtoXML(json_response):
 def buildFlagDict(ifo,name,version,known_segments,active_segments):
     """
     Helper function to build a flag_version dictionary for JSON production.
-    
+
     known_segments and active_segments are assumed to be segmentlist objects
-    Note that this currently does not generate a false "query_metadata" block        
+    Note that this currently does not generate a false "query_metadata" block
     """
     flag={}
     flag['ifo']=ifo
@@ -95,8 +95,8 @@ def buildFlagDict(ifo,name,version,known_segments,active_segments):
 
 
 class FlagVersion(object):
-    """ 
-    Class to set up a flag version object for parsing into JSON 
+    """
+    Class to set up a flag version object for parsing into JSON
     """
     def __init__(self,ifo,name,version):
         self.known=segments.segmentlist([])
@@ -110,14 +110,14 @@ class FlagVersion(object):
         url=server+'/dq/'+'/'.join([str(self.ifo),str(self.name),str(self.version)])
         return url
     def appendKnown(self,known_segments):
-        """ Appends a segmentlist of known segments to the existing known 
+        """ Appends a segmentlist of known segments to the existing known
         segments for the object, and coalesces.
         """
         # known_segments must be a segmentlist object
         self.known=self.known+known_segments
         self.known.coalesce()
     def appendActive(self,active_segments):
-        """ Appends a segmentlist of active segments to the existing active 
+        """ Appends a segmentlist of active segments to the existing active
         segments for the object, and coalesces.
         """
         # active_segments must be a segmentlist object
@@ -128,8 +128,8 @@ class FlagVersion(object):
         self.flagDict=buildFlagDict(self.ifo,self.name,self.version,self.known,self.active)
 
 class PatchFlagVersion(FlagVersion):
-    __doc__ = FlagVersion.__doc__ + """ 
-    Class to extend basic flag version class to include insert_history 
+    __doc__ = FlagVersion.__doc__ + """
+    Class to extend basic flag version class to include insert_history
     """
     def __init__(self,ifo,name,version,hackDec11=False):
         self.known=segments.segmentlist([])
@@ -139,7 +139,7 @@ class PatchFlagVersion(FlagVersion):
         self.ifo=ifo
         self.name=name
         self.version=version
-        self.temp_process_ids={} # Used to hold the data 
+        self.temp_process_ids={} # Used to hold the data
         #                         # associated with a process_id
         if hackDec11:
             self.insert_history={}
@@ -201,8 +201,8 @@ class PatchFlagVersion(FlagVersion):
 
 
 class InsertFlagVersion(PatchFlagVersion):
-    __doc__ = PatchFlagVersion.__doc__ + """ 
-    Adds metadata for initial inserts 
+    __doc__ = PatchFlagVersion.__doc__ + """
+    Adds metadata for initial inserts
     """
     def __init__(self,ifo,name,version):
         super(InsertFlagVersion, self).__init__(ifo,name,version)
@@ -225,8 +225,8 @@ class InsertFlagVersion(PatchFlagVersion):
         self.flagDict['metadata']['active_indicates_ifo_badness']=self.active_indicates_ifo_badness
 
 class InsertFlagVersionOld(PatchFlagVersion):
-    __doc__ = PatchFlagVersion.__doc__ + """ 
-    Adds metadata for initial inserts 
+    __doc__ = PatchFlagVersion.__doc__ + """
+    Adds metadata for initial inserts
     """
     def __init__(self,ifo,name,version):
         super(InsertFlagVersionOld, self).__init__(ifo,name,version)
@@ -247,26 +247,26 @@ class InsertFlagVersionOld(PatchFlagVersion):
         self.flagDict['metadata']['provenance_url']=self.provenance_url
         self.flagDict['metadata']['deactivated']=self.deactivated
         self.flagDict['metadata']['active_indicates_ifo_badness']=self.active_indicates_ifo_badness
-    
+
 
 ################################################################################
 #
-#  Helper functions to convert segmentlist to json list of lists type object 
+#  Helper functions to convert segmentlist to json list of lists type object
 #  and vice versa
 #
 ################################################################################
 
 def convert_segmentlist_to_json(segmentlist_input):
-    """ 
-    Helper function used to convert segmentlist to json list of lists type 
+    """
+    Helper function used to convert segmentlist to json list of lists type
     object.
     """
     json_list=[[x[0],x[1]] for x in segmentlist_input]
     return json_list
 
 def convert_json_list_to_segmentlist(jsonlist):
-     """ 
-     Helper function used to convert json list of lists type object to a 
+     """
+     Helper function used to convert json list of lists type object to a
      segmentlist object
      """
      segment_list=segments.segmentlist([segments.segment(x[0],x[1]) for x in jsonlist])
@@ -353,7 +353,7 @@ def generated_ascii(json_str,filepath):
 #     "inserted_data_end": gpstime, // Last gpstime of data this insertion describes
 #     "process_start_timestamp": gpstime, // When the insert process was started, use to determine run time of inserts
 #     // NOT to be added by client code -- these are server-side annotations, prior to insertion into the DB
-#     "auth_user" : "user identification" // from the auth infrastructure used to talk to the server 
+#     "auth_user" : "user identification" // from the auth infrastructure used to talk to the server
 #     "insert_timestamp" : gpstime,    // when the insert was committed to the DB
 #    },
 #    "flag" : {
@@ -364,7 +364,7 @@ def generated_ascii(json_str,filepath):
 #         "deactivated" : false|true,
 #         "active_indicates_ifo_badness" : true|false|null,
 #         // all of the above will be needed for /dq/IFO/FLAG inserts
-#         "version" : n,  
+#         "version" : n,
 #         // all of the above will be needed for /dq/IFO/FLAG/VERSION inserts
 #         // all of the below are required for /dq/IFO/FLAG/VERSION/active inserts
 #         "known" : [ [ts,te], [ts,te], ... ]

--- a/dqsegdb/jsonhelper.py
+++ b/dqsegdb/jsonhelper.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import json

--- a/dqsegdb/urifunctions.py
+++ b/dqsegdb/urifunctions.py
@@ -27,7 +27,7 @@ import re
 #
 # =============================================================================
 #
-#                Library for DQSEGDB API Providing URL Functions 
+#                Library for DQSEGDB API Providing URL Functions
 #
 # =============================================================================
 #
@@ -132,7 +132,7 @@ def getDataUrllib2(url,timeout=900,logger=None,warnings=True):
 
 def constructSegmentQueryURLTimeWindow(protocol,server,ifo,name,version,include_list_string,startTime,endTime):
     """
-    Simple url construction method for dqsegdb server flag:version queries 
+    Simple url construction method for dqsegdb server flag:version queries
     including restrictions on time ranges.
 
     Parameters
@@ -166,9 +166,9 @@ def constructSegmentQueryURLTimeWindow(protocol,server,ifo,name,version,include_
 
 def constructSegmentQueryURL(protocol,server,ifo,name,version,include_list_string):
     """
-    Simple url construction method for dqsegdb server flag:version queries 
+    Simple url construction method for dqsegdb server flag:version queries
     not including restrictions on time ranges.
-    
+
     Parameters
     ----------
     protocol : `string`
@@ -191,8 +191,8 @@ def constructSegmentQueryURL(protocol,server,ifo,name,version,include_list_strin
 
 def constructVersionQueryURL(protocol,server,ifo,name):
     """
-    Simple url construction method for dqsegdb server version queries. 
-    
+    Simple url construction method for dqsegdb server version queries.
+
     Parameters
     ----------
     protocol : `string`
@@ -211,8 +211,8 @@ def constructVersionQueryURL(protocol,server,ifo,name):
 
 def constructFlagQueryURL(protocol,server,ifo):
     """
-    Simple url construction method for dqsegdb server flag queries. 
-    
+    Simple url construction method for dqsegdb server flag queries.
+
     Parameters
     ----------
     protocol : `string`
@@ -285,7 +285,7 @@ def putDataUrllib2(url,payload,timeout=900,logger=None):
 def patchDataUrllib2(url,payload,timeout=900,logger=None):
     """
     Wrapper method for urllib2 that supports PATCHs to a url.
-    
+
     Parameters
     ----------
     url : `string`
@@ -337,7 +337,7 @@ def patchDataUrllib2(url,payload,timeout=900,logger=None):
 def handleHTTPError(method,url,e):
     if int(e.code)!=404:
         warnings.warn("Warning: Issue accessing url: %s" % url)
-        warnings.warn("Code: %s" % str(e.code)) 
+        warnings.warn("Code: %s" % str(e.code))
         warnings.warn("Message: %s" % str(e.msg))
         #print e.reason
         #print url

--- a/dqsegdb/urifunctions.py
+++ b/dqsegdb/urifunctions.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2015 Ryan Fisher, Gary Hemming
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
 # published by the Free Software Foundation, either version 3 of the
 # License, or (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import warnings
@@ -360,12 +360,12 @@ def handleHTTPError(method,url,e):
 # terms of the GNU General Public License as published by the Free Software
 # Foundation, either version 3 of the License, or (at your option) any later
 # version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
-# 
+#
 # You should have received a copy of the GNU General Public License along with
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #


### PR DESCRIPTION
This PR fixes ~350 whitespace 'errors' by stripping all trailing whitespace from lines.

I manually didn't strip whitespace from `print` statements, so as not to clash with changes in #18.