### PR TITLE
Removed unused imports

### DIFF
--- a/bin/ligolw_dq_query_dqsegdb
+++ b/bin/ligolw_dq_query_dqsegdb
@@ -47,7 +47,6 @@ from glue import segments
 
 from glue import git_version
 
-from dqsegdb import urifunctions
 from dqsegdb import apicalls
 import json
 import urlparse

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb
@@ -36,12 +36,8 @@ import traceback
 import copy
 import pwd
 import os
-import re
-import exceptions
 import signal
 import re
-import time
-import glob
 import logging
 import logging.handlers
 
@@ -49,14 +45,11 @@ from optparse import OptionParser
 
 from glue import lal
 from glue import segments
-from glue import gpstime
 from glue import segmentsUtils
 from glue import pidfile
 
 from glue.ligolw import ligolw
-from glue.ligolw import lsctables
 from glue.ligolw import utils as ligolw_utils
-from glue.ligolw.utils import segments as ligolw_segments
 from glue.ligolw.utils import process as ligolw_process
 # ER6 Glue fixes:
 from glue.ligolw import table

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
@@ -70,7 +70,6 @@ import traceback
 import copy
 import pwd
 import os
-import re
 import signal
 import logging
 import logging.handlers

--- a/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
+++ b/bin/ligolw_publish_threaded_dqxml_dqsegdb_hacked
@@ -71,11 +71,7 @@ import copy
 import pwd
 import os
 import re
-import exceptions
 import signal
-import re
-import time
-import glob
 import logging
 import logging.handlers
 
@@ -83,14 +79,11 @@ from optparse import OptionParser
 
 from glue import lal
 from glue import segments
-from glue import gpstime
 from glue import segmentsUtils
 from glue import pidfile
 
 from glue.ligolw import ligolw
-from glue.ligolw import lsctables
 from glue.ligolw import utils as ligolw_utils
-from glue.ligolw.utils import segments as ligolw_segments
 from glue.ligolw.utils import process as ligolw_process
 
 from glue.segmentdb import segmentdb_utils

--- a/bin/ligolw_segment_insert_dqsegdb
+++ b/bin/ligolw_segment_insert_dqsegdb
@@ -15,24 +15,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ###################################################################
+
+from __future__ import print_function
+
 import socket
 import os
 import socket
 import atexit
 import pwd
-import re
 import urlparse
 import time
 import sys
-import commands
 import StringIO
 import logging
 import logging.handlers
-import exceptions
-import binascii
 from optparse import OptionParser
 from dqsegdb import apicalls
-from dqsegdb import jsonhelper
 import json
 
 try:
@@ -54,8 +52,7 @@ try:
   from glue import ldbd
   from glue import segments
   from glue import git_version
-  from glue.segmentdb import segmentdb_utils
-  from glue.ligolw import table
+  #from glue.segmentdb import segmentdb_utils
   from glue.ligolw import lsctables
   from glue.ligolw import ligolw
   from glue.ligolw.utils import process

--- a/bin/ligolw_segment_query_dqsegdb
+++ b/bin/ligolw_segment_query_dqsegdb
@@ -46,12 +46,8 @@ from optparse import OptionParser
 import sys
 import warnings
 import os
-import math
-import operator
+#import operator
 import pwd
-import glob
-import time
-import socket
 import tempfile
 import urllib
 import urlparse
@@ -67,7 +63,6 @@ from glue.ligolw import table
 from glue.ligolw import lsctables
 from glue.ligolw import utils
 
-from glue.ligolw.utils import ligolw_add
 from glue.ligolw.utils import process
 from glue.segmentdb import query_engine
 from glue.segmentdb import segmentdb_utils

--- a/bin/ligolw_segments_from_cats_dqsegdb
+++ b/bin/ligolw_segments_from_cats_dqsegdb
@@ -37,12 +37,6 @@ from __future__ import print_function
 from optparse import OptionParser
 import urlparse
 
-try:
-    import sqlite3
-except ImportError:
-    # pre 2.5.x
-    from pysqlite2 import dbapi2 as sqlite3
-
 import sys
 import os
 import pwd
@@ -54,7 +48,6 @@ import time
 from glue import gpstime
 
 from glue.ligolw import ligolw
-from glue.ligolw import lsctables
 from glue.ligolw import utils
 from glue.ligolw.utils import ligolw_sqlite
 from glue.ligolw import dbtables

--- a/dqsegdb/__init__.py
+++ b/dqsegdb/__init__.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import *
-
 # set version metadata
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/dqsegdb/urifunctions.py
+++ b/dqsegdb/urifunctions.py
@@ -24,7 +24,6 @@ import socket
 import calendar
 import time
 import os
-import re
 from OpenSSL import crypto
 
 #


### PR DESCRIPTION
This PR removes unused imports from all `bin/` scripts and all `dqsegdb` modules. This should have no functional impact on any codes.