### PR TITLE
Fix glue package names in system package files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ X-Python-Version: >= 2.6
 
 Package: python-dqsegdb
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), python-lscsoft-glue (>= 1.55), pyrxp | python-pyrxp, python-gwdatafind, python-ligo-segments
+Depends: ${shlibs:Depends}, ${misc:Depends}, python (>=2.6), python-glue (>= 1.55), pyrxp | python-pyrxp, python-gwdatafind, python-ligo-segments
 Description: dqsegdb client
  This package provides the client tools to connect to LIGO/VIRGO
   DQSEGDB instances.

--- a/etc/dqsegdb.spec
+++ b/etc/dqsegdb.spec
@@ -13,7 +13,7 @@ License: GPLv3
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
-Requires: python, python-pyRXP, lscsoft-glue >= 1.55, python2-gwdatafind
+Requires: python, python-pyRXP, glue >= 1.55, python2-gwdatafind
 Requires: python2-ligo-segments
 BuildRequires: python-setuptools, git
 BuildArch: noarch


### PR DESCRIPTION
This PR fixes the misnamed `glue` dependencies in the system packages file for debian/rhel.