### PR TITLE
Add SciTokens authorization

### DIFF
--- a/server/install_scripts/cit_install_script.sh
+++ b/server/install_scripts/cit_install_script.sh
@@ -96,6 +96,7 @@ cp ~/dqsegdb/server/src/* .
 cd /root
 
 # Add WSGI script alias to Apache configuration file.
+echo "WSGIPassAuthorization On" >> /etc/httpd/conf.d/wsgi.conf
 echo "WSGIScriptAlias / /opt/dqsegdb/python_server/src/application.py" >> /etc/httpd/conf.d/wsgi.conf
 
 
@@ -177,6 +178,9 @@ cp /etc/grid-security/*.ligo.org.key /etc/pki/tls/private/localhost.key
 yum -y install cilogon-ca-certs
 yum -y install osg-ca-certs
 yum -y install ligo-ca-certs
+
+# Install the scitokens package:
+yum -y install python2-scitokens
 
 # Start Apache server.
 chkconfig httpd on

--- a/server/install_scripts/cit_install_script_sl7update.sh
+++ b/server/install_scripts/cit_install_script_sl7update.sh
@@ -156,6 +156,9 @@ if [ $run_block_2 -eq 1 ]; then   # * Apache, MariaDB, etc., installation
   # Install Apache WSGI module.
   yum -y install mod_wsgi
 
+  # Install SciTokens
+  yum -y install python2-scitokens
+
   # Install MariaDB, set it to run on startup, and start it
   yum -y install mariadb-server mariadb mariadb-devel
   ### not started until later - b/c we want to change the buffer pool size first?

--- a/server/install_scripts/install_script.sh
+++ b/server/install_scripts/install_script.sh
@@ -88,6 +88,7 @@ tar -xvf src.tar
 cd /root
 
 # Add WSGI script alias to Apache configuration file.
+echo "WSGIPassAuthorization On" >> /etc/httpd/conf.d/wsgi.conf
 echo "WSGIScriptAlias / /opt/dqsegdb/python_server/src/application.py" >> /etc/httpd/conf.d/wsgi.conf
 
 # Add Web Interface configuration.
@@ -111,6 +112,9 @@ sed -i "s/10\.20\.5\.43/${int_addr}/g" /etc/httpd/conf.d/dqsegdb.conf
 
 # Install M2Crypto library.
 yum -y install M2Crypto
+
+# Install the scitokens package:
+yum -y install python2-scitokens
 
 # Restart Apache.
 /etc/init.d/httpd restart

--- a/server/src/Constants.py
+++ b/server/src/Constants.py
@@ -72,6 +72,12 @@ class ConstantsHandle():
     grid_map_get_file = '/etc/grid-security/grid-mapfile'  # Grid Map file used in authentication.
     grid_map_put_patch_file = '/etc/grid-security/grid-mapfile-insert'  # Grid Map file used in authorisation.
 
+    ########################
+    # SciTokens constants #
+    ######################
+    scitokens_issuer = 'https://test.cilogon.org'
+    scitokens_audience = 'segments.ligo.org'
+
     #################################
     # Sub-second segment constants #
     ###############################

--- a/server/src/Constants.py
+++ b/server/src/Constants.py
@@ -75,7 +75,7 @@ class ConstantsHandle():
     ########################
     # SciTokens constants #
     ######################
-    scitokens_issuer = 'https://demo.scitokens.org'
+    scitokens_issuer = 'https://test.cilogon.org/'
     scitokens_audience = 'segments.ligo.org'
     scitokens_cache_dir = '/var/cache/httpd'
 

--- a/server/src/Constants.py
+++ b/server/src/Constants.py
@@ -1,27 +1,17 @@
-# Copyright (C) 2014-2020 Syracuse University, European Gravitational Observatory, and Christopher Newport University.  Written by Ryan Fisher and Gary Hemming. See the NOTICE file distributed with this work for additional information regarding copyright ownership.
-
+# Copyright (C) 2014-2020 Syracuse University, European Gravitational Observatory, and Christopher Newport University.
+# Written by Ryan Fisher, Gary Hemming, and Duncan Brown.
+# See the NOTICE file distributed with this work for additional information regarding copyright ownership.
 # This program is free software: you can redistribute it and/or modify
-
 # it under the terms of the GNU Affero General Public License as
-
 # published by the Free Software Foundation, either version 3 of the
-
 # License, or (at your option) any later version.
-
 #
-
 # This program is distributed in the hope that it will be useful,
-
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-
 # GNU Affero General Public License for more details.
-
 #
-
 # You should have received a copy of the GNU Affero General Public License
-
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 DQSEGDB Python Server
@@ -75,7 +65,7 @@ class ConstantsHandle():
     ########################
     # SciTokens constants #
     ######################
-    scitokens_issuer = 'https://test.cilogon.org/'
+    scitokens_issuer = 'https://test.cilogon.org'
     scitokens_audience = 'segments.ligo.org'
     scitokens_cache_dir = '/var/cache/httpd'
 

--- a/server/src/Constants.py
+++ b/server/src/Constants.py
@@ -75,8 +75,9 @@ class ConstantsHandle():
     ########################
     # SciTokens constants #
     ######################
-    scitokens_issuer = 'https://test.cilogon.org'
+    scitokens_issuer = 'https://demo.scitokens.org'
     scitokens_audience = 'segments.ligo.org'
+    scitokens_cache_dir = '/var/cache/httpd'
 
     #################################
     # Sub-second segment constants #

--- a/server/src/LDBDWAuth.py
+++ b/server/src/LDBDWAuth.py
@@ -26,6 +26,8 @@ import exceptions
 import M2Crypto
 import re
 import scitokens
+from jwt.exceptions import InvalidAudienceError
+from jwt.exceptions import ExpiredSignatureError
 
 class GridMapError(exceptions.Exception):
     """
@@ -263,13 +265,15 @@ class SciTokensAuthorization():
                 if self.token_enforcer.test(token, "write", "/DQSegDB"):
                     r = [200]
                 else:
-                    r = self.admin.log_and_set_http_code(401, c, req_method, "SciToken not valid for write access", full_uri)
+                    r = self.admin.log_and_set_http_code(401, c, req_method,
+                        "SciToken not valid for write access: %s" % str(token['scope']), full_uri)
             # GET
             else:
                 if self.token_enforcer.test(token, "read", "/DQSegDB"):
                     r = [200]
                 else:
-                    r = self.admin.log_and_set_http_code(401, c, req_method, "SciToken not valid for read access", full_uri)
+                    r = self.admin.log_and_set_http_code(401, c, req_method,
+                        "SciToken not valid for read access: %s" % str(token['scope']) , full_uri)
 
         # Return.
         return r

--- a/server/src/application.py
+++ b/server/src/application.py
@@ -1,27 +1,17 @@
-# Copyright (C) 2014-2020 Syracuse University, European Gravitational Observatory, and Christopher Newport University.  Written by Ryan Fisher and Gary Hemming. See the NOTICE file distributed with this work for additional information regarding copyright ownership.
-
+# Copyright (C) 2014-2020 Syracuse University, European Gravitational Observatory, and Christopher Newport University.
+# Written by Ryan Fisher, Gary Hemming, and Duncan Brown. 
+# See the NOTICE file distributed with this work for additional information regarding copyright ownership.
 # This program is free software: you can redistribute it and/or modify
-
 # it under the terms of the GNU Affero General Public License as
-
 # published by the Free Software Foundation, either version 3 of the
-
 # License, or (at your option) any later version.
-
 #
-
 # This program is distributed in the hope that it will be useful,
-
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-
 # GNU Affero General Public License for more details.
-
 #
-
 # You should have received a copy of the GNU Affero General Public License
-
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 DQSEGDB Python Server
@@ -46,6 +36,7 @@ def application(environ, start_response):
     admin = Admin.AdminHandle()
     dao = DAO.DAOHandle()
     reqhan = Request.RequestHandle()
+    ldbdsauth = LDBDWAuth.SciTokensAuthorization()
     ldbdwauth = LDBDWAuth.GridmapAuthorization()
     # Set HTTP code and log.
     res = admin.log_and_set_http_code(400, 0, environ['REQUEST_METHOD'], None, environ['REQUEST_URI'])
@@ -54,7 +45,10 @@ def application(environ, start_response):
         # Respond to a GET request.
         if environ['REQUEST_METHOD'] == 'GET':
             # Authenticate.
-            res = ldbdwauth.check_authorization_gridmap(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], False)
+            try:
+                res = ldbdsauth.check_authorization_scitoken(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], False)
+            except:
+                res = ldbdwauth.check_authorization_gridmap(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], False)
             # If authentication successful.
             if res[0] == 200:
                 # Get content for output.
@@ -62,7 +56,10 @@ def application(environ, start_response):
         # Respond to a PUT request.
         elif environ['REQUEST_METHOD'] == 'PUT' or environ['REQUEST_METHOD'] == 'PATCH':
             # Authorise.
-            res = ldbdwauth.check_authorization_gridmap(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], True)
+            try:
+                res = ldbdsauth.check_authorization_scitoken(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], True)
+            except:
+                res = ldbdwauth.check_authorization_gridmap(environ, environ['REQUEST_METHOD'], environ['REQUEST_URI'], True)
             # If authorisation successful.
             if res[0] == 200:
                 # Get the size of the requested JSON.


### PR DESCRIPTION
This pull requests adds authorization using [SciTokens](https://scitokens.org) to the SegDB WSGI server. The SciToken should be passed in the https authorization header as
```
Authorization: Bearer serialized_token_text
````
where `serialized_token_text` is a serialized SciToken generated by a the issuer specified in `scitokens_issuer` in `Constants.py`. The SegDB server and the SciToken issuer need to agree on the audience for tokens, which is specified in `scitokens_audience` in `Constants.py`.

`GET` access to obtain segments is given to SegDB if the token scope is `read:/DQSegDB` and `PUT` and `PATCH` access to insert and update segments is given if the token scope is `write:/DQSegDB`.

If the request does not contain a valid SciToken, or the token cannot be deserialized for the right audience, the server will silently fail over to trying X509 authentication. If a SciToken is provided with the correct audience, the server will fail if the token does not contain the correct scope for the  requested action and will not fall through to X509 authentication.

One this patch is merged, the SciTokens library must be installed on the server with `yum -y install python2-scitokens`. This has been added to the install scripts.

WSGI must to be configured to pass the authorization headers to the python layer with `WSGIPassAuthorization On` in `wsgi.conf`. See https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIPassAuthorization.html for details. I think I did this correctly in the `cit_install_script.sh` and `install_script.sh` files, but in `cit_install_script_sl7update.sh` the file `wsgi.conf` seems to be coming from some cached location, so that file may need to be fixed separately.

In addition, the following configuration values need to be set to their production settings before deployment:
```
scitokens_issuer = 'https://test.cilogon.org'
scitokens_audience = 'segments.ligo.org'
```
The `scitokens_issuer` should be the URL of the scitokens issuer against which scitokens should be validated. The `scitokens_audience` should be the audience that is agreed for the SegDB server(s).

This patch hard codes the scitoken scopes as `read:/DQSegSB` for GET access to the segment database and `write:/DQSegSB` for PUT/PATCH access to the segment database. These scopes need to be agreed collaboration-wide. It might also make sense to make them configuration variables as well, rather than being hard coded.

Scitokens caches keys in a cache directory which is set in the configuration file to
```
scitokens_cache_dir = '/var/cache/httpd'
```
This directory should exist and have read/write by the DQSegDB server process, or should be changed to another suitable location.