### PR TITLE
add minimal pytest suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,13 +62,16 @@ jobs:
         # install LAL (for glue)
         python -m pip install lalsuite
         # install test-only requirements
-        python -m pip install coveralls
+        python -m pip install pytest pytest-cov
 
     - name: Install DQSegDB
       run: python -m pip install --editable . --no-build-isolation -vv
 
     - name: Package list
       run: python -m pip list installed
+
+    - name: Run pytest suite
+      run: python -m pytest -ra --pyargs dqsegdb.tests --cov dqsegdb --junitxml=pytest.xml
 
     - name: Run command line tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         rm -fv .coverage
 
     - name: Publish coverage to Codecov
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
       with:
         flags: ${{ runner.os }},python${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       run: python -m pip list installed
 
     - name: Run pytest suite
-      run: python -m pytest -ra --pyargs dqsegdb.tests --cov dqsegdb --junitxml=pytest.xml
+      run: python -m pytest -ra --pyargs dqsegdb.tests --cov dqsegdb --cov-report= --junitxml=pytest.xml
 
     - name: Run command line tests
       run: |

--- a/dqsegdb/tests/__init__.py
+++ b/dqsegdb/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8
+
+"""Test suite for DQSegDB client
+"""

--- a/dqsegdb/tests/test_urifunctions.py
+++ b/dqsegdb/tests/test_urifunctions.py
@@ -36,3 +36,26 @@ def test_constructSegmentQueryURL():
         "https://segments.ligo.org"
         "/dq/L1/TEST-FLAG/1?include=metadata"
     )
+
+
+def test_constructVersionQueryURL():
+    assert urifunctions.constructVersionQueryURL(
+        "https",
+        "segments.ligo.org",
+        "L1",
+        "TEST-FLAG",
+    ) == (
+        "https://segments.ligo.org"
+        "/dq/L1/TEST-FLAG"
+    )
+
+
+def test_constructFlagQueryURL():
+    assert urifunctions.constructFlagQueryURL(
+        "https",
+        "segments.ligo.org",
+        "L1",
+    ) == (
+        "https://segments.ligo.org"
+        "/dq/L1"
+    )

--- a/dqsegdb/tests/test_urifunctions.py
+++ b/dqsegdb/tests/test_urifunctions.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for `dqsegdb.urifunctions`
+"""
+
+from unittest import mock
+
+from .. import urifunctions
+
+
+def test_constructSegmentQueryURLTimeWindow():
+    assert urifunctions.constructSegmentQueryURLTimeWindow(
+        "https",
+        "segments.ligo.org",
+        "L1",
+        "TEST-FLAG",
+        1,
+        "metadata",
+        100,
+        200,
+    ) == (
+        "https://segments.ligo.org"
+        "/dq/L1/TEST-FLAG/1?s=100&e=200&include=metadata"
+    )
+
+
+def test_constructSegmentQueryURL():
+    assert urifunctions.constructSegmentQueryURL(
+        "https",
+        "segments.ligo.org",
+        "L1",
+        "TEST-FLAG",
+        "1",
+        "metadata",
+    ) == (
+        "https://segments.ligo.org"
+        "/dq/L1/TEST-FLAG/1?include=metadata"
+    )


### PR DESCRIPTION
This PR adds a pytest suite in `dqsegdb/tests` with a couple of small tests, mainly as a placeholder for some real tests, and reconfigures the CI to run the test suite.

This should enable easy addition of other tests that increase the coverage of the project.