### PR TITLE
Fix posting data to a URL

### DIFF
--- a/dqsegdb/apicalls.py
+++ b/dqsegdb/apicalls.py
@@ -664,6 +664,13 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
     that can be directly dumped to JSON that the dqsegdb server expects.
     Correctly fails at making a new version or flag in the database as needed.
     """
+    # translate dict data to bytes in a compact representation
+    data = json.dumps(
+        i.flagDict,
+        indent=None,
+        separators=(",",":"),
+    ).encode("utf-8")
+
     try:
         #patch to the flag/version
         if debug:
@@ -673,7 +680,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
             startTime=testing_options['synchronize']
             inlogger.debug("Trying to patch synchronously at time %s" % startTime)
             waitTill(startTime)
-        patchDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
+        patchDataUrllib2(url,data,logger=inlogger)
         if debug:
             inlogger.debug("Patch alone succeeded for %s" % url)
             #print("Patch alone succeeded for %s" % url)
@@ -685,7 +692,7 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
             if debug:
                 inlogger.debug("Trying to put alone for url: %s" % url)
                 #print("Trying to put alone for %s" % url)
-            putDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
+            putDataUrllib2(url,data,logger=inlogger)
             if debug:
                 inlogger.debug("Put alone succeeded for %s" % url)
                 #print("Put alone succeeded for %s" % url)
@@ -697,9 +704,9 @@ def patchWithFailCases(i,url,debug=True,inlogger=None,testing_options={}):
             if debug:
                 inlogger.debug("Trying to PUT flag and version to: %s" % suburl)
                 #print("Trying to PUT flag and version to: "+suburl)
-            putDataUrllib2(suburl,json.dumps(i.flagDict),logger=inlogger)
+            putDataUrllib2(suburl,data,logger=inlogger)
             #put to version
-            putDataUrllib2(url,json.dumps(i.flagDict),logger=inlogger)
+            putDataUrllib2(url,data,logger=inlogger)
             if debug:
                 inlogger.debug("Had to PUT flag and version")
                 #print("Had to PUT flag and version")

--- a/dqsegdb/urifunctions.py
+++ b/dqsegdb/urifunctions.py
@@ -194,7 +194,8 @@ def putDataUrllib2(url,payload,timeout=900,logger=None,
     #    opener=urllib_request.build_opener(HTTPSClientAuthHandler)
     #else:
     #    opener = urllib_request.build_opener(urllib_request.HTTPHandler)
-    if isinstance(payload, str): payload = payload.encode('utf-8')    # P3 fix
+    if isinstance(payload, str):
+        payload = payload.encode('utf-8')
     request = urllib_request.Request(url, data=payload)
     request.add_header('Content-Type', 'JSON')
     request.get_method = lambda: 'PUT'
@@ -257,6 +258,8 @@ def patchDataUrllib2(url,payload,timeout=900,logger=None,
     #else:
     #    opener = urllib_request.build_opener(urllib_request.HTTPHandler)
     #print(opener.handle_open.items())
+    if isinstance(payload, str):
+        payload = payload.encode('utf-8')
     request = urllib_request.Request(url, data=payload)
     request.add_header('Content-Type', 'JSON')
     request.get_method = lambda: 'PATCH'
@@ -264,7 +267,6 @@ def patchDataUrllib2(url,payload,timeout=900,logger=None,
         logger.debug("Beginning URL call: %s" % url)
     try:
         #urlreturned = opener.open(request)
-        if isinstance(request.data, str): request.data = request.data.encode('utf-8')   # P3 fix
         urlreturned = urllib_request.urlopen(request, timeout=timeout, **urlopen_kw)
     except urllib_error.HTTPError as e:
         handleHTTPError("PATCH",url,e)


### PR DESCRIPTION
This PR fixes a bug in `dqsegdb.apicalls.patchWithFailCases` where data were being submitted to `urlllib.request.Request` as `str`, not `bytes`.