### PR TITLE
Remove python3.5 test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
           - macOS
           - Ubuntu
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8


### PR DESCRIPTION
This PR removes the Python 3.5 test job, that version of Python is no longer supported.