### PR TITLE
Informs about change to new repo and exits setup.py to prevent instal…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ dqsegdb
 [![Build and test](https://github.com/ligovirgo/dqsegdb/actions/workflows/test.yml/badge.svg)](https://github.com/ligovirgo/dqsegdb/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/ligovirgo/dqsegdb/branch/master/graph/badge.svg?token=4q02Rv0Gkw)](https://codecov.io/gh/ligovirgo/dqsegdb)
 
+NOTICE: This repo has moved, as of Sept. 2022.  The code in this GitHub repo ( https://github.com/ligovirgo/dqsegdb ) is not being updated any more.  The new DQSegDB repo is https://git.ligo.org/computing/dqsegdb, with the code split up as follows:
+- server code: https://git.ligo.org/computing/dqsegdb/server
+- client tools: https://git.ligo.org/computing/dqsegdb/client
+- web server code: https://git.ligo.org/computing/dqsegdb/web
+
+The current code in this (GitHub) repo will not likely be installable without manual modification, to prevent users from accidentally installing an old version of the code.
+
+All information below this line is preserved from before the repo moved, and some of it is already obsolete.
+=======
 
 DQSEGDB client library and functions
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ AUTHOR = 'Ryan Fisher'
 AUTHOR_EMAIL = 'ryan.fisher@ligo.org'
 LICENSE = 'GPLv3'
 
+print("This version of the dqsegdb code is obsolete.  Please see https://git.ligo.org/computing/dqsegdb/ for the current code.")
+print("This code has been modified to prevent accidental installation of the obsolete code.  You should only modify and install it if you *really* know what you're doing.")
+exit()
+
 # -- versioning ---------------------------------------------------------------
 
 import versioneer


### PR DESCRIPTION
…lation

The repo at https://github.com/ligovirgo/dqsegdb has been moved to https://git.ligo.org/computing/dqsegdb/.  This is noted in the README.md file, and setup.py now prints a message about the change and exits, to prevent users from accidentally installing the old code.  Users can modify that file if they know what they're doing and want to do it anyway.